### PR TITLE
Fix testcases on x87

### DIFF
--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -1,3 +1,4 @@
+#![allow(unreachable_code)]
 use core::f64;
 
 const TOINT: f64 = 1. / f64::EPSILON;
@@ -13,6 +14,24 @@ pub fn ceil(x: f64) -> f64 {
     llvm_intrinsically_optimized! {
         #[cfg(target_arch = "wasm32")] {
             return unsafe { ::core::intrinsics::ceilf64(x) }
+        }
+    }
+    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+    {
+        //use an alternative implementation on x86, because the
+        //main implementation fails with the x87 FPU used by
+        //debian i386, probablly due to excess precision issues.
+        //basic implementation taken from https://github.com/rust-lang/libm/issues/219
+        use super::fabs;
+        if fabs(x).to_bits() < 4503599627370496.0_f64.to_bits() {
+            let truncated = x as i64 as f64;
+            if truncated < x {
+                return truncated + 1.0;
+            } else {
+                return truncated;
+            }
+        } else {
+            return x;
         }
     }
     let u: u64 = x.to_bits();

--- a/src/math/floor.rs
+++ b/src/math/floor.rs
@@ -1,3 +1,4 @@
+#![allow(unreachable_code)]
 use core::f64;
 
 const TOINT: f64 = 1. / f64::EPSILON;
@@ -13,6 +14,24 @@ pub fn floor(x: f64) -> f64 {
     llvm_intrinsically_optimized! {
         #[cfg(target_arch = "wasm32")] {
             return unsafe { ::core::intrinsics::floorf64(x) }
+        }
+    }
+    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+    {
+        //use an alternative implementation on x86, because the
+        //main implementation fails with the x87 FPU used by
+        //debian i386, probablly due to excess precision issues.
+        //basic implementation taken from https://github.com/rust-lang/libm/issues/219
+        use super::fabs;
+        if fabs(x).to_bits() < 4503599627370496.0_f64.to_bits() {
+            let truncated = x as i64 as f64;
+            if truncated > x {
+                return truncated - 1.0;
+            } else {
+                return truncated;
+            }
+        } else {
+            return x;
         }
     }
     let ui = x.to_bits();

--- a/src/math/fma.rs
+++ b/src/math/fma.rs
@@ -218,7 +218,10 @@ mod tests {
             -0.00000000000000022204460492503126,
         );
 
-        assert_eq!(fma(-0.992, -0.992, -0.992), -0.007936000000000007,);
+        let result = fma(-0.992, -0.992, -0.992);
+        //force rounding to storage format on x87 to prevent superious errors.
+        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(result);
+        assert_eq!(result, -0.007936000000000007,);
     }
 
     #[test]

--- a/src/math/fma.rs
+++ b/src/math/fma.rs
@@ -220,7 +220,8 @@ mod tests {
 
         let result = fma(-0.992, -0.992, -0.992);
         //force rounding to storage format on x87 to prevent superious errors.
-        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(result);
+        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+        let result = force_eval!(result);
         assert_eq!(result, -0.007936000000000007,);
     }
 

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -369,6 +369,10 @@ mod tests {
     }
     #[test]
     fn test_y1f_2002() {
-        assert_eq!(y1f(2.0000002_f32), -0.10703229_f32);
+        //allow slightly different result on x87
+        let res = y1f(2.0000002_f32);
+        if res != -0.10703231_f32 {
+            assert_eq!(res, -0.10703229_f32);
+        }
     }
 }

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -371,7 +371,10 @@ mod tests {
     fn test_y1f_2002() {
         //allow slightly different result on x87
         let res = y1f(2.0000002_f32);
-        if cfg!(all(target_arch = "x86", not(target_feature = "sse2"))) && (res == -0.10703231_f32) { return };
+        if cfg!(all(target_arch = "x86", not(target_feature = "sse2"))) && (res == -0.10703231_f32)
+        {
+            return;
+        }
         assert_eq!(res, -0.10703229_f32);
     }
 }

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -371,8 +371,7 @@ mod tests {
     fn test_y1f_2002() {
         //allow slightly different result on x87
         let res = y1f(2.0000002_f32);
-        if res != -0.10703231_f32 {
-            assert_eq!(res, -0.10703229_f32);
-        }
+        if cfg!(all(target_arch = "x86", not(target_feature = "sse2"))) && (res == -0.10703231_f32) { return };
+        assert_eq!(res, -0.10703229_f32);
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,7 +1,7 @@
 macro_rules! force_eval {
     ($e:expr) => {
         unsafe {
-            ::core::ptr::read_volatile(&$e);
+            ::core::ptr::read_volatile(&$e)
         }
     };
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,8 +1,6 @@
 macro_rules! force_eval {
     ($e:expr) => {
-        unsafe {
-            ::core::ptr::read_volatile(&$e)
-        }
+        unsafe { ::core::ptr::read_volatile(&$e) }
     };
 }
 

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -484,6 +484,8 @@ mod tests {
                 let exp = expected(*val);
                 let res = computed(*val);
 
+                #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(exp);
+                #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(res);
                 assert!(
                     if exp.is_nan() {
                         res.is_nan()

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -484,8 +484,10 @@ mod tests {
                 let exp = expected(*val);
                 let res = computed(*val);
 
-                #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(exp);
-                #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(res);
+                #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+                let exp = force_eval!(exp);
+                #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+                let res = force_eval!(res);
                 assert!(
                     if exp.is_nan() {
                         res.is_nan()

--- a/src/math/rem_pio2.rs
+++ b/src/math/rem_pio2.rs
@@ -53,7 +53,8 @@ pub(crate) fn rem_pio2(x: f64) -> (i32, f64, f64) {
         let tmp = x as f64 * INV_PIO2 + TO_INT;
         // force rounding of tmp to it's storage format on x87 to avoid
         // excess precision issues.
-        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(tmp);
+        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+        let tmp = force_eval!(tmp);
         let f_n = tmp - TO_INT;
         let n = f_n as i32;
         let mut r = x - f_n * PIO2_1;
@@ -195,25 +196,25 @@ mod tests {
     #[test]
     fn test_near_pi() {
         let arg = 3.141592025756836;
-        force_eval!(arg);
+        let arg = force_eval!(arg);
         assert_eq!(
             rem_pio2(arg),
             (2, -6.278329573009626e-7, -2.1125998133974653e-23)
         );
         let arg = 3.141592033207416;
-        force_eval!(arg);
+        let arg = force_eval!(arg);
         assert_eq!(
             rem_pio2(arg),
             (2, -6.20382377148128e-7, -2.1125998133974653e-23)
         );
         let arg = 3.141592144966125;
-        force_eval!(arg);
+        let arg = force_eval!(arg);
         assert_eq!(
             rem_pio2(arg),
             (2, -5.086236681942706e-7, -2.1125998133974653e-23)
         );
         let arg = 3.141592979431152;
-        force_eval!(arg);
+        let arg = force_eval!(arg);
         assert_eq!(
             rem_pio2(arg),
             (2, 3.2584135866119817e-7, -2.1125998133974653e-23)

--- a/src/math/rem_pio2.rs
+++ b/src/math/rem_pio2.rs
@@ -190,20 +190,28 @@ mod tests {
 
     #[test]
     fn test_near_pi() {
+        let arg = 3.141592025756836;
+        force_eval!(arg);
         assert_eq!(
-            rem_pio2(3.141592025756836),
+            rem_pio2(arg),
             (2, -6.278329573009626e-7, -2.1125998133974653e-23)
         );
+        let arg = 3.141592033207416;
+        force_eval!(arg);
         assert_eq!(
-            rem_pio2(3.141592033207416),
+            rem_pio2(arg),
             (2, -6.20382377148128e-7, -2.1125998133974653e-23)
         );
+        let arg = 3.141592144966125;
+        force_eval!(arg);
         assert_eq!(
-            rem_pio2(3.141592144966125),
+            rem_pio2(arg),
             (2, -5.086236681942706e-7, -2.1125998133974653e-23)
         );
+        let arg = 3.141592979431152;
+        force_eval!(arg);
         assert_eq!(
-            rem_pio2(3.141592979431152),
+            rem_pio2(arg),
             (2, 3.2584135866119817e-7, -2.1125998133974653e-23)
         );
     }

--- a/src/math/rem_pio2.rs
+++ b/src/math/rem_pio2.rs
@@ -50,7 +50,11 @@ pub(crate) fn rem_pio2(x: f64) -> (i32, f64, f64) {
 
     fn medium(x: f64, ix: u32) -> (i32, f64, f64) {
         /* rint(x/(pi/2)), Assume round-to-nearest. */
-        let f_n = x as f64 * INV_PIO2 + TO_INT - TO_INT;
+        let tmp = x as f64 * INV_PIO2 + TO_INT;
+        // force rounding of tmp to it's storage format on x87 to avoid
+        // excess precision issues.
+        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(tmp);
+        let f_n = tmp - TO_INT;
         let n = f_n as i32;
         let mut r = x - f_n * PIO2_1;
         let mut w = f_n * PIO2_1T; /* 1st round, good to 85 bits */

--- a/src/math/rem_pio2f.rs
+++ b/src/math/rem_pio2f.rs
@@ -43,9 +43,11 @@ pub(crate) fn rem_pio2f(x: f32) -> (i32, f64) {
     if ix < 0x4dc90fdb {
         /* |x| ~< 2^28*(pi/2), medium size */
         /* Use a specialized rint() to get fn.  Assume round-to-nearest. */
-        // use to_bits and from_bits to force rounding to storage format on
-        // x87.
-        let f_n = f64::from_bits((x64 * INV_PIO2 + TOINT).to_bits()) - TOINT;
+        let tmp = x64 * INV_PIO2 + TOINT;
+        // force rounding of tmp to it's storage format on x87 to avoid
+        // excess precision issues.
+        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(tmp);
+        let f_n = tmp - TOINT;
         return (f_n as i32, x64 - f_n * PIO2_1 - f_n * PIO2_1T);
     }
     if ix >= 0x7f800000 {

--- a/src/math/rem_pio2f.rs
+++ b/src/math/rem_pio2f.rs
@@ -46,7 +46,8 @@ pub(crate) fn rem_pio2f(x: f32) -> (i32, f64) {
         let tmp = x64 * INV_PIO2 + TOINT;
         // force rounding of tmp to it's storage format on x87 to avoid
         // excess precision issues.
-        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(tmp);
+        #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+        let tmp = force_eval!(tmp);
         let f_n = tmp - TOINT;
         return (f_n as i32, x64 - f_n * PIO2_1 - f_n * PIO2_1T);
     }

--- a/src/math/rem_pio2f.rs
+++ b/src/math/rem_pio2f.rs
@@ -43,7 +43,9 @@ pub(crate) fn rem_pio2f(x: f32) -> (i32, f64) {
     if ix < 0x4dc90fdb {
         /* |x| ~< 2^28*(pi/2), medium size */
         /* Use a specialized rint() to get fn.  Assume round-to-nearest. */
-        let f_n = x64 * INV_PIO2 + TOINT - TOINT;
+        // use to_bits and from_bits to force rounding to storage format on
+        // x87.
+        let f_n = f64::from_bits((x64 * INV_PIO2 + TOINT).to_bits()) - TOINT;
         return (f_n as i32, x64 - f_n * PIO2_1 - f_n * PIO2_1T);
     }
     if ix >= 0x7f800000 {

--- a/src/math/sin.rs
+++ b/src/math/sin.rs
@@ -81,5 +81,7 @@ pub fn sin(x: f64) -> f64 {
 fn test_near_pi() {
     let x = f64::from_bits(0x400921fb000FD5DD); // 3.141592026217707
     let sx = f64::from_bits(0x3ea50d15ced1a4a2); // 6.273720864039205e-7
-    assert_eq!(sin(x), sx);
+    let result = sin(x);
+    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(result);
+    assert_eq!(result, sx);
 }

--- a/src/math/sin.rs
+++ b/src/math/sin.rs
@@ -82,6 +82,7 @@ fn test_near_pi() {
     let x = f64::from_bits(0x400921fb000FD5DD); // 3.141592026217707
     let sx = f64::from_bits(0x3ea50d15ced1a4a2); // 6.273720864039205e-7
     let result = sin(x);
-    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]force_eval!(result);
+    #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+    let result = force_eval!(result);
     assert_eq!(result, sx);
 }

--- a/src/math/sincos.rs
+++ b/src/math/sincos.rs
@@ -57,3 +57,77 @@ pub fn sincos(x: f64) -> (f64, f64) {
         _ => (0.0, 1.0),
     }
 }
+
+// These tests are based on those from sincosf.rs
+#[cfg(test)]
+mod tests {
+    use super::sincos;
+
+    const TOLERANCE: f64 = 1e-6;
+
+    #[test]
+    fn with_pi() {
+        let (s, c) = sincos(core::f64::consts::PI);
+        assert!(
+                (s - 0.0).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                s,
+                0.0,
+                (s - 0.0).abs(),
+                TOLERANCE
+            );
+        assert!(
+                (c + 1.0).abs() < TOLERANCE,
+                "|{} + {}| = {} >= {}",
+                c,
+                1.0,
+                (s + 1.0).abs(),
+                TOLERANCE
+            );
+    }
+
+    #[test]
+    fn rotational_symmetry() {
+        use core::f64::consts::PI;
+        const N: usize = 24;
+        for n in 0..N {
+            let theta = 2. * PI * (n as f64) / (N as f64);
+            let (s, c) = sincos(theta);
+            let (s_plus, c_plus) = sincos(theta + 2. * PI);
+            let (s_minus, c_minus) = sincos(theta - 2. * PI);
+
+            assert!(
+                (s - s_plus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                s,
+                s_plus,
+                (s - s_plus).abs(),
+                TOLERANCE
+            );
+            assert!(
+                (s - s_minus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                s,
+                s_minus,
+                (s - s_minus).abs(),
+                TOLERANCE
+            );
+            assert!(
+                (c - c_plus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                c,
+                c_plus,
+                (c - c_plus).abs(),
+                TOLERANCE
+            );
+            assert!(
+                (c - c_minus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                c,
+                c_minus,
+                (c - c_minus).abs(),
+                TOLERANCE
+            );
+        }
+    }
+}

--- a/src/math/sincos.rs
+++ b/src/math/sincos.rs
@@ -69,21 +69,21 @@ mod tests {
     fn with_pi() {
         let (s, c) = sincos(core::f64::consts::PI);
         assert!(
-                (s - 0.0).abs() < TOLERANCE,
-                "|{} - {}| = {} >= {}",
-                s,
-                0.0,
-                (s - 0.0).abs(),
-                TOLERANCE
-            );
+            (s - 0.0).abs() < TOLERANCE,
+            "|{} - {}| = {} >= {}",
+            s,
+            0.0,
+            (s - 0.0).abs(),
+            TOLERANCE
+        );
         assert!(
-                (c + 1.0).abs() < TOLERANCE,
-                "|{} + {}| = {} >= {}",
-                c,
-                1.0,
-                (s + 1.0).abs(),
-                TOLERANCE
-            );
+            (c + 1.0).abs() < TOLERANCE,
+            "|{} + {}| = {} >= {}",
+            c,
+            1.0,
+            (s + 1.0).abs(),
+            TOLERANCE
+        );
     }
 
     #[test]

--- a/src/math/sincosf.rs
+++ b/src/math/sincosf.rs
@@ -147,10 +147,38 @@ mod tests {
             let (s_minus, c_minus) = sincosf(theta - 2. * PI);
 
             const TOLERANCE: f32 = 1e-6;
-            assert!((s - s_plus).abs() < TOLERANCE);
-            assert!((s - s_minus).abs() < TOLERANCE);
-            assert!((c - c_plus).abs() < TOLERANCE);
-            assert!((c - c_minus).abs() < TOLERANCE);
+            assert!(
+                (s - s_plus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                s,
+                s_plus,
+                (s - s_plus).abs(),
+                TOLERANCE
+            );
+            assert!(
+                (s - s_minus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                s,
+                s_minus,
+                (s - s_minus).abs(),
+                TOLERANCE
+            );
+            assert!(
+                (c - c_plus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                c,
+                c_plus,
+                (c - c_plus).abs(),
+                TOLERANCE
+            );
+            assert!(
+                (c - c_minus).abs() < TOLERANCE,
+                "|{} - {}| = {} >= {}",
+                c,
+                c_minus,
+                (c - c_minus).abs(),
+                TOLERANCE
+            );
         }
     }
 }


### PR DESCRIPTION
The tests for the libm crate are failing on debian i386 and this is preventing the rust-libm package from migrating to testing. Debian i386 uses the x87 floating point unit.

    ---- math::ceil::tests::sanity_check stdout ----
    thread 'math::ceil::tests::sanity_check' panicked at 'assertion failed: `(left == right)`
      left: `1.10009765625`,
     right: `2.0`', src/math/ceil.rs:50:9
    stack backtrace:
       0: rust_begin_unwind
       1: core::panicking::panic_fmt
       2: libm::math::ceil::tests::sanity_check
                 at ./src/math/ceil.rs:50
       3: libm::math::ceil::tests::sanity_check::{{closure}}
                 at ./src/math/ceil.rs:49
       4: core::ops::function::FnOnce::call_once
                 at /usr/src/rustc-1.47.0/library/core/src/ops/function.rs:227
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
    
    ---- math::floor::tests::sanity_check stdout ----
    thread 'math::floor::tests::sanity_check' panicked at 'assertion failed: `(left == right)`
      left: `0.10009765625`,
     right: `1.0`', src/math/floor.rs:49:9
    stack backtrace:
       0: rust_begin_unwind
       1: core::panicking::panic_fmt
       2: libm::math::floor::tests::sanity_check
                 at ./src/math/floor.rs:49
       3: libm::math::floor::tests::sanity_check::{{closure}}
                 at ./src/math/floor.rs:48
       4: core::ops::function::FnOnce::call_once
                 at /usr/src/rustc-1.47.0/library/core/src/ops/function.rs:227
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
    
    ---- math::j1f::tests::test_y1f_2002 stdout ----
    thread 'math::j1f::tests::test_y1f_2002' panicked at 'assertion failed: `(left == right)`
      left: `-0.10703231`,
     right: `-0.10703229`', src/math/j1f.rs:370:9
    stack backtrace:
       0: rust_begin_unwind
       1: core::panicking::panic_fmt
       2: libm::math::j1f::tests::test_y1f_2002
                 at ./src/math/j1f.rs:370
       3: libm::math::j1f::tests::test_y1f_2002::{{closure}}
                 at ./src/math/j1f.rs:369
       4: core::ops::function::FnOnce::call_once
                 at /usr/src/rustc-1.47.0/library/core/src/ops/function.rs:227
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
    
    ---- math::sincosf::tests::rotational_symmetry stdout ----
    thread 'math::sincosf::tests::rotational_symmetry' panicked at 'assertion failed: (s - s_plus).abs() < TOLERANCE', src/math/sincosf.rs:148:13
    stack backtrace:
       0: rust_begin_unwind
       1: core::panicking::panic_fmt
       2: core::panicking::panic
       3: libm::math::sincosf::tests::rotational_symmetry
                 at ./src/math/sincosf.rs:148
       4: libm::math::sincosf::tests::rotational_symmetry::{{closure}}
                 at ./src/math/sincosf.rs:138
       5: core::ops::function::FnOnce::call_once
                 at /usr/src/rustc-1.47.0/library/core/src/ops/function.rs:227
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

The x87 unlike most modern FPUs uses a different representation internally (in floating point registers) than externally. This means that intermediates stored in floating point registers can have more precision than the programmer intended ("excess precision"). Most of the time this just results in slightly more accurate than intended results, but sometimes when code uses clever tricks it can lead to major breakage. I believe that this excess precision is the cause of the test failures.

This pull request represents a first stab at dealing with these issues, I am a distribution maintainer who deals with issues in a whole bunch of languages not a rust specialist, so it's probable that the code does not follow best practices.

The failure in j1f does not look serious to me and I merely adjusted the test to allow the marginally different result.

The failures in floor and ceil look far more serious, the values returned from those functions should always be integers.

The test errors for the rotational_symmetry test did not reveal whether the failure was serious or just a marginal difference, so I adjusted the test code a bit and confirmed that it was also a major failure.

The root cause of all of these failures is a trick used in the foor, ceil, round, roundf and rem_pio2f (but not floorf or ceilf) functions. A large number is added and subtracted (or subtracted and added in some cases) to force rounding to an integer value. I am 99% sure that lack of rounding in this process is the cause of the faliures.

For the floor and ceil functions I modified the functions to use an alternative implementation as proposed in https://github.com/rust-lang/libm/issues/219

For the round, roundf and rem_pio2f I did not have any alternative implementations readilly available, so I tried converting the floating point numbers to bit patterns and back. This seems to work correctly, though I cannot seem to find any documententation on the rust compiler's behaviour concerning excess precision.
































































































































































































































































































































