### PR TITLE
add "readme"-key to Cargo.toml in order for this crate to have a preview on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ documentation = "https://docs.rs/libm"
 keywords = ["libm", "math"]
 license = "MIT OR Apache-2.0"
 name = "libm"
+readme = "README.md"
 repository = "https://github.com/rust-lang/libm"
 version = "0.2.1"
 edition = "2018"


### PR DESCRIPTION
Right now there is no nice preview/readme on crates.io. This PR fixes this (with the next release that contains this change.)