### PR TITLE
Fix substract with borrow in FMA

### DIFF
--- a/src/math/fma.rs
+++ b/src/math/fma.rs
@@ -122,9 +122,9 @@ pub fn fma(x: f64, y: f64, z: f64) -> f64 {
         rhi += zhi + (rlo < zlo) as u64;
     } else {
         /* r -= z */
-        let t = rlo;
-        rlo = rlo.wrapping_sub(zlo);
-        rhi = rhi.wrapping_sub(zhi.wrapping_sub((t < rlo) as u64));
+        let (res, borrow) = rlo.overflowing_sub(zlo);
+        rlo = res;
+        rhi = rhi.wrapping_sub(zhi.wrapping_add(borrow as u64));
         if (rhi >> 63) != 0 {
             rlo = (-(rlo as i64)) as u64;
             rhi = (-(rhi as i64)) as u64 - (rlo != 0) as u64;
@@ -218,6 +218,14 @@ mod tests {
             -0.00000000000000022204460492503126,
         );
 
-        assert_eq!(fma(-0.992, -0.992, -0.992), -0.00793599999988632,);
+        assert_eq!(fma(-0.992, -0.992, -0.992), -0.007936000000000007,);
+    }
+
+    #[test]
+    fn fma_sbb() {
+        assert_eq!(
+            fma(-(1.0 - f64::EPSILON), f64::MIN, f64::MIN),
+            -3991680619069439e277
+        );
     }
 }

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -604,7 +604,7 @@ mod tests {
 
         // Factoring -1 out:
         // (negative anything ^ integer should be (-1 ^ integer) * (positive anything ^ integer))
-        &[POS_ZERO, NEG_ZERO, POS_ONE, NEG_ONE, POS_EVENS, NEG_EVENS]
+        (&[POS_ZERO, NEG_ZERO, POS_ONE, NEG_ONE, POS_EVENS, NEG_EVENS])
             .iter()
             .for_each(|int_set| {
                 int_set.iter().for_each(|int| {
@@ -616,7 +616,7 @@ mod tests {
 
         // Negative base (imaginary results):
         // (-anything except 0 and Infinity ^ non-integer should be NAN)
-        &NEG[1..(NEG.len() - 1)].iter().for_each(|set| {
+        (&NEG[1..(NEG.len() - 1)]).iter().for_each(|set| {
             set.iter().for_each(|val| {
                 test_sets(&ALL[3..7], &|v: f64| pow(*val, v), &|_| NAN);
             })


### PR DESCRIPTION
Fixes #242

I assume there's a good reason we're not just using u128 math here.