### PR TITLE
Optimize round and roundf

### DIFF
--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -1,36 +1,10 @@
+use super::copysignf;
+use super::truncf;
 use core::f32;
 
-const TOINT: f32 = 1.0 / f32::EPSILON;
-
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn roundf(mut x: f32) -> f32 {
-    let i = x.to_bits();
-    let e: u32 = i >> 23 & 0xff;
-    let mut y: f32;
-
-    if e >= 0x7f + 23 {
-        return x;
-    }
-    if e < 0x7f - 1 {
-        force_eval!(x + TOINT);
-        return 0.0 * x;
-    }
-    if i >> 31 != 0 {
-        x = -x;
-    }
-    y = x + TOINT - TOINT - x;
-    if y > 0.5f32 {
-        y = y + x - 1.0;
-    } else if y <= -0.5f32 {
-        y = y + x + 1.0;
-    } else {
-        y = y + x;
-    }
-    if i >> 31 != 0 {
-        -y
-    } else {
-        y
-    }
+pub fn roundf(x: f32) -> f32 {
+    truncf(x + copysignf(0.5 - 0.25 * f32::EPSILON, x))
 }
 
 #[cfg(test)]
@@ -40,5 +14,15 @@ mod tests {
     #[test]
     fn negative_zero() {
         assert_eq!(roundf(-0.0_f32).to_bits(), (-0.0_f32).to_bits());
+    }
+
+    #[test]
+    fn sanity_check() {
+        assert_eq!(roundf(-1.0), -1.0);
+        assert_eq!(roundf(2.8), 3.0);
+        assert_eq!(roundf(-0.5), -1.0);
+        assert_eq!(roundf(0.5), 1.0);
+        assert_eq!(roundf(-1.5), -2.0);
+        assert_eq!(roundf(1.5), 2.0);
     }
 }


### PR DESCRIPTION
In reference to #154, this optimizes the `round` and `roundf` functions.  This does not change the behavior at all.

I compared all f32 values to verify that the behavior of `roundf` has not changed.

For `round`, I directly translated the `roundf` function and verified that it behaved the same with random bits for the sign and exponent and beginning and end of the mantissa.

I ran some criterion benchmarks and basically both functions went from about 7ns to about 3ns.

```
round/round             time:   [7.1414 ns 7.1470 ns 7.1543 ns]                         
round/round_new         time:   [3.0178 ns 3.0311 ns 3.0471 ns]                             

roundf/roundf           time:   [6.8636 ns 6.8767 ns 6.9016 ns]                           
roundf/roundf_new       time:   [2.8326 ns 2.8401 ns 2.8562 ns]                               
```