### PR TITLE
updated link to musl website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A port of [MUSL]'s libm to Rust.
 
-[MUSL]: https://www.musl-libc.org/
+[MUSL]: https://musl.libc.org/
 
 ## Goals
 


### PR DESCRIPTION
Updated the link(https://www.musl-libc.org) to https://musl.libc.org.