### PR TITLE
[Blocked] Use const fn where easily applicable.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@
 #![allow(clippy::float_cmp)]
 #![allow(clippy::eq_op)]
 #![allow(clippy::assign_op_pattern)]
+#![deny(clippy::missing_const_for_fn)]
+#![feature(const_float_bits_conv)]
+#![feature(const_fn_floating_point_arithmetic)]
+#![feature(const_float_classify)]
 
 mod math;
 

--- a/src/math/copysign.rs
+++ b/src/math/copysign.rs
@@ -2,7 +2,7 @@
 ///
 /// Constructs a number with the magnitude (absolute value) of its
 /// first argument, `x`, and the sign of its second argument, `y`.
-pub fn copysign(x: f64, y: f64) -> f64 {
+pub const fn copysign(x: f64, y: f64) -> f64 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= (!0) >> 1;

--- a/src/math/copysignf.rs
+++ b/src/math/copysignf.rs
@@ -2,7 +2,7 @@
 ///
 /// Constructs a number with the magnitude (absolute value) of its
 /// first argument, `x`, and the sign of its second argument, `y`.
-pub fn copysignf(x: f32, y: f32) -> f32 {
+pub const fn copysignf(x: f32, y: f32) -> f32 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= 0x7fffffff;

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -4,7 +4,7 @@ use core::u64;
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fabs(x: f64) -> f64 {
+pub const fn fabs(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f64.abs` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -2,7 +2,7 @@
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fabsf(x: f32) -> f32 {
+pub const fn fabsf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f32.abs` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/fdim.rs
+++ b/src/math/fdim.rs
@@ -9,7 +9,7 @@ use core::f64;
 ///
 /// A range error may occur.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fdim(x: f64, y: f64) -> f64 {
+pub const fn fdim(x: f64, y: f64) -> f64 {
     if x.is_nan() {
         x
     } else if y.is_nan() {

--- a/src/math/fdimf.rs
+++ b/src/math/fdimf.rs
@@ -9,7 +9,7 @@ use core::f32;
 ///
 /// A range error may occur.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fdimf(x: f32, y: f32) -> f32 {
+pub const fn fdimf(x: f32, y: f32) -> f32 {
     if x.is_nan() {
         x
     } else if y.is_nan() {

--- a/src/math/fenv.rs
+++ b/src/math/fenv.rs
@@ -8,26 +8,26 @@ pub(crate) const FE_TONEAREST: i32 = 0;
 pub(crate) const FE_TOWARDZERO: i32 = 0;
 
 #[inline]
-pub(crate) fn feclearexcept(_mask: i32) -> i32 {
+pub(crate) const fn feclearexcept(_mask: i32) -> i32 {
     0
 }
 
 #[inline]
-pub(crate) fn feraiseexcept(_mask: i32) -> i32 {
+pub(crate) const fn feraiseexcept(_mask: i32) -> i32 {
     0
 }
 
 #[inline]
-pub(crate) fn fetestexcept(_mask: i32) -> i32 {
+pub(crate) const fn fetestexcept(_mask: i32) -> i32 {
     0
 }
 
 #[inline]
-pub(crate) fn fegetround() -> i32 {
+pub(crate) const fn fegetround() -> i32 {
     FE_TONEAREST
 }
 
 #[inline]
-pub(crate) fn fesetround(_r: i32) -> i32 {
+pub(crate) const fn fesetround(_r: i32) -> i32 {
     0
 }

--- a/src/math/fma.rs
+++ b/src/math/fma.rs
@@ -10,7 +10,7 @@ struct Num {
     sign: i32,
 }
 
-fn normalize(x: f64) -> Num {
+const fn normalize(x: f64) -> Num {
     let x1p63: f64 = f64::from_bits(0x43e0000000000000); // 0x1p63 === 2 ^ 63
 
     let mut ix: u64 = x.to_bits();
@@ -29,7 +29,7 @@ fn normalize(x: f64) -> Num {
     Num { m: ix, e, sign }
 }
 
-fn mul(x: u64, y: u64) -> (u64, u64) {
+const fn mul(x: u64, y: u64) -> (u64, u64) {
     let t1: u64;
     let t2: u64;
     let t3: u64;
@@ -52,7 +52,7 @@ fn mul(x: u64, y: u64) -> (u64, u64) {
 /// Computes the value (as if) to infinite precision and rounds once to the result format,
 /// according to the rounding mode characterized by the value of FLT_ROUNDS.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fma(x: f64, y: f64, z: f64) -> f64 {
+pub const fn fma(x: f64, y: f64, z: f64) -> f64 {
     let x1p63: f64 = f64::from_bits(0x43e0000000000000); // 0x1p63 === 2 ^ 63
     let x0_ffffff8p_63 = f64::from_bits(0x3bfffffff0000000); // 0x0.ffffff8p-63
 

--- a/src/math/fmax.rs
+++ b/src/math/fmax.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmax(x: f64, y: f64) -> f64 {
+pub const fn fmax(x: f64, y: f64) -> f64 {
     // IEEE754 says: maxNum(x, y) is the canonicalized number y if x < y, x if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fmaxf.rs
+++ b/src/math/fmaxf.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmaxf(x: f32, y: f32) -> f32 {
+pub const fn fmaxf(x: f32, y: f32) -> f32 {
     // IEEE754 says: maxNum(x, y) is the canonicalized number y if x < y, x if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fmin.rs
+++ b/src/math/fmin.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmin(x: f64, y: f64) -> f64 {
+pub const fn fmin(x: f64, y: f64) -> f64 {
     // IEEE754 says: minNum(x, y) is the canonicalized number x if x < y, y if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fminf.rs
+++ b/src/math/fminf.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fminf(x: f32, y: f32) -> f32 {
+pub const fn fminf(x: f32, y: f32) -> f32 {
     // IEEE754 says: minNum(x, y) is the canonicalized number x if x < y, y if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fmod.rs
+++ b/src/math/fmod.rs
@@ -1,7 +1,7 @@
 use core::u64;
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmod(x: f64, y: f64) -> f64 {
+pub const fn fmod(x: f64, y: f64) -> f64 {
     let mut uxi = x.to_bits();
     let mut uyi = y.to_bits();
     let mut ex = (uxi >> 52 & 0x7ff) as i64;

--- a/src/math/fmodf.rs
+++ b/src/math/fmodf.rs
@@ -2,7 +2,7 @@ use core::f32;
 use core::u32;
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmodf(x: f32, y: f32) -> f32 {
+pub const fn fmodf(x: f32, y: f32) -> f32 {
     let mut uxi = x.to_bits();
     let mut uyi = y.to_bits();
     let mut ex = (uxi >> 23 & 0xff) as i32;

--- a/src/math/frexp.rs
+++ b/src/math/frexp.rs
@@ -1,4 +1,4 @@
-pub fn frexp(x: f64) -> (f64, i32) {
+pub const fn frexp(x: f64) -> (f64, i32) {
     let mut y = x.to_bits();
     let ee = ((y >> 52) & 0x7ff) as i32;
 

--- a/src/math/frexpf.rs
+++ b/src/math/frexpf.rs
@@ -1,4 +1,4 @@
-pub fn frexpf(x: f32) -> (f32, i32) {
+pub const fn frexpf(x: f32) -> (f32, i32) {
     let mut y = x.to_bits();
     let ee: i32 = ((y >> 23) & 0xff) as i32;
 

--- a/src/math/k_cos.rs
+++ b/src/math/k_cos.rs
@@ -52,7 +52,7 @@ const C6: f64 = -1.13596475577881948265e-11; /* 0xBDA8FAE9, 0xBE8838D4 */
 //         under FreeBSD, so don't pessimize things by forcibly clipping
 //         any extra precision in w.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub(crate) fn k_cos(x: f64, y: f64) -> f64 {
+pub(crate) const fn k_cos(x: f64, y: f64) -> f64 {
     let z = x * x;
     let w = z * z;
     let r = z * (C1 + z * (C2 + z * C3)) + w * w * (C4 + z * (C5 + z * C6));

--- a/src/math/k_cosf.rs
+++ b/src/math/k_cosf.rs
@@ -21,7 +21,7 @@ const C2: f64 = -0.00138867637746099294692; /* -0x16c087e80f1e27.0p-62 */
 const C3: f64 = 0.0000243904487962774090654; /*  0x199342e0ee5069.0p-68 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub(crate) fn k_cosf(x: f64) -> f32 {
+pub(crate) const fn k_cosf(x: f64) -> f32 {
     let z = x * x;
     let w = z * z;
     let r = C2 + z * C3;

--- a/src/math/k_sin.rs
+++ b/src/math/k_sin.rs
@@ -44,7 +44,7 @@ const S6: f64 = 1.58969099521155010221e-10; /* 0x3DE5D93A, 0x5ACFD57C */
 //         then                   3    2
 //              sin(x) = x + (S1*x + (x *(r-y/2)+y))
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub(crate) fn k_sin(x: f64, y: f64, iy: i32) -> f64 {
+pub(crate) const fn k_sin(x: f64, y: f64, iy: i32) -> f64 {
     let z = x * x;
     let w = z * z;
     let r = S2 + z * (S3 + z * S4) + z * w * (S5 + z * S6);

--- a/src/math/k_sinf.rs
+++ b/src/math/k_sinf.rs
@@ -21,7 +21,7 @@ const S3: f64 = -0.000198393348360966317347; /* -0x1a00f9e2cae774.0p-65 */
 const S4: f64 = 0.0000027183114939898219064; /*  0x16cd878c3b46a7.0p-71 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub(crate) fn k_sinf(x: f64) -> f32 {
+pub(crate) const fn k_sinf(x: f64) -> f32 {
     let z = x * x;
     let w = z * z;
     let r = S3 + z * S4;

--- a/src/math/k_tan.rs
+++ b/src/math/k_tan.rs
@@ -40,7 +40,7 @@
 //      4. For x in [0.67434,pi/4],  let y = pi/4 - x, then
 //              tan(x) = tan(pi/4-y) = (1-tan(y))/(1+tan(y))
 //                     = 1 - 2*(tan(y) - (tan(y)^2)/(1+tan(y)))
-static T: [f64; 13] = [
+const T: [f64; 13] = [
     3.33333333333334091986e-01,  /* 3FD55555, 55555563 */
     1.33333333333201242699e-01,  /* 3FC11111, 1110FE7A */
     5.39682539762260521377e-02,  /* 3FABA1BA, 1BB341FE */
@@ -59,7 +59,7 @@ const PIO4: f64 = 7.85398163397448278999e-01; /* 3FE921FB, 54442D18 */
 const PIO4_LO: f64 = 3.06161699786838301793e-17; /* 3C81A626, 33145C07 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub(crate) fn k_tan(mut x: f64, mut y: f64, odd: i32) -> f64 {
+pub(crate) const fn k_tan(mut x: f64, mut y: f64, odd: i32) -> f64 {
     let hx = (f64::to_bits(x) >> 32) as u32;
     let big = (hx & 0x7fffffff) >= 0x3FE59428; /* |x| >= 0.6744 */
     if big {
@@ -100,6 +100,6 @@ pub(crate) fn k_tan(mut x: f64, mut y: f64, odd: i32) -> f64 {
     a0 + a * (1.0 + a0 * w0 + a0 * v)
 }
 
-fn zero_low_word(x: f64) -> f64 {
+const fn zero_low_word(x: f64) -> f64 {
     f64::from_bits(f64::to_bits(x) & 0xFFFF_FFFF_0000_0000)
 }

--- a/src/math/k_tanf.rs
+++ b/src/math/k_tanf.rs
@@ -20,7 +20,7 @@ const T: [f64; 6] = [
 ];
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub(crate) fn k_tanf(x: f64, odd: bool) -> f32 {
+pub(crate) const fn k_tanf(x: f64, odd: bool) -> f32 {
     let z = x * x;
     /*
      * Split up the polynomial into small independent terms to give

--- a/src/math/ldexp.rs
+++ b/src/math/ldexp.rs
@@ -1,4 +1,4 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn ldexp(x: f64, n: i32) -> f64 {
+pub const fn ldexp(x: f64, n: i32) -> f64 {
     super::scalbn(x, n)
 }

--- a/src/math/ldexpf.rs
+++ b/src/math/ldexpf.rs
@@ -1,4 +1,4 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn ldexpf(x: f32, n: i32) -> f32 {
+pub const fn ldexpf(x: f32, n: i32) -> f32 {
     super::scalbnf(x, n)
 }

--- a/src/math/log.rs
+++ b/src/math/log.rs
@@ -71,7 +71,7 @@ const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log(mut x: f64) -> f64 {
+pub const fn log(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui = x.to_bits();

--- a/src/math/log10.rs
+++ b/src/math/log10.rs
@@ -32,7 +32,7 @@ const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log10(mut x: f64) -> f64 {
+pub const fn log10(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui: u64 = x.to_bits();

--- a/src/math/log10f.rs
+++ b/src/math/log10f.rs
@@ -26,7 +26,7 @@ const LG3: f32 = 0.28498786688; /* 0x91e9ee.0p-25 */
 const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log10f(mut x: f32) -> f32 {
+pub const fn log10f(mut x: f32) -> f32 {
     let x1p25f = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25
 
     let mut ui: u32 = x.to_bits();

--- a/src/math/log2.rs
+++ b/src/math/log2.rs
@@ -30,7 +30,7 @@ const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log2(mut x: f64) -> f64 {
+pub const fn log2(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui: u64 = x.to_bits();
@@ -97,7 +97,7 @@ pub fn log2(mut x: f64) -> f64 {
     val_lo = (lo + hi) * IVLN2LO + lo * IVLN2HI;
 
     /* spadd(val_hi, val_lo, y), except for not using double_t: */
-    y = k.into();
+    y = k as f64;
     w = y + val_hi;
     val_lo += (y - w) + val_hi;
     val_hi = w;

--- a/src/math/log2f.rs
+++ b/src/math/log2f.rs
@@ -24,7 +24,7 @@ const LG3: f32 = 0.28498786688; /* 0x91e9ee.0p-25 */
 const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log2f(mut x: f32) -> f32 {
+pub const fn log2f(mut x: f32) -> f32 {
     let x1p25f = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25
 
     let mut ui: u32 = x.to_bits();

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -335,17 +335,17 @@ use self::rem_pio2_large::rem_pio2_large;
 use self::rem_pio2f::rem_pio2f;
 
 #[inline]
-fn get_high_word(x: f64) -> u32 {
+const fn get_high_word(x: f64) -> u32 {
     (x.to_bits() >> 32) as u32
 }
 
 #[inline]
-fn get_low_word(x: f64) -> u32 {
+const fn get_low_word(x: f64) -> u32 {
     x.to_bits() as u32
 }
 
 #[inline]
-fn with_set_high_word(f: f64, hi: u32) -> f64 {
+const fn with_set_high_word(f: f64, hi: u32) -> f64 {
     let mut tmp = f.to_bits();
     tmp &= 0x00000000_ffffffff;
     tmp |= (hi as u64) << 32;
@@ -353,7 +353,7 @@ fn with_set_high_word(f: f64, hi: u32) -> f64 {
 }
 
 #[inline]
-fn with_set_low_word(f: f64, lo: u32) -> f64 {
+const fn with_set_low_word(f: f64, lo: u32) -> f64 {
     let mut tmp = f.to_bits();
     tmp &= 0xffffffff_00000000;
     tmp |= lo as u64;
@@ -361,6 +361,6 @@ fn with_set_low_word(f: f64, lo: u32) -> f64 {
 }
 
 #[inline]
-fn combine_words(hi: u32, lo: u32) -> f64 {
+const fn combine_words(hi: u32, lo: u32) -> f64 {
     f64::from_bits((hi as u64) << 32 | lo as u64)
 }

--- a/src/math/modf.rs
+++ b/src/math/modf.rs
@@ -1,4 +1,4 @@
-pub fn modf(x: f64) -> (f64, f64) {
+pub const fn modf(x: f64) -> (f64, f64) {
     let rv2: f64;
     let mut u = x.to_bits();
     let mask: u64;

--- a/src/math/modff.rs
+++ b/src/math/modff.rs
@@ -1,4 +1,4 @@
-pub fn modff(x: f32) -> (f32, f32) {
+pub const fn modff(x: f32) -> (f32, f32) {
     let rv2: f32;
     let mut u: u32 = x.to_bits();
     let mask: u32;

--- a/src/math/remainder.rs
+++ b/src/math/remainder.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn remainder(x: f64, y: f64) -> f64 {
+pub const fn remainder(x: f64, y: f64) -> f64 {
     let (result, _) = super::remquo(x, y);
     result
 }

--- a/src/math/remainderf.rs
+++ b/src/math/remainderf.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn remainderf(x: f32, y: f32) -> f32 {
+pub const fn remainderf(x: f32, y: f32) -> f32 {
     let (result, _) = super::remquof(x, y);
     result
 }

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
+pub const fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
     let ux: u64 = x.to_bits();
     let mut uy: u64 = y.to_bits();
     let mut ex = ((ux >> 52) & 0x7ff) as i32;

--- a/src/math/remquof.rs
+++ b/src/math/remquof.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn remquof(mut x: f32, mut y: f32) -> (f32, i32) {
+pub const fn remquof(mut x: f32, mut y: f32) -> (f32, i32) {
     let ux: u32 = x.to_bits();
     let mut uy: u32 = y.to_bits();
     let mut ex = ((ux >> 23) & 0xff) as i32;

--- a/src/math/scalbn.rs
+++ b/src/math/scalbn.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn scalbn(x: f64, mut n: i32) -> f64 {
+pub const fn scalbn(x: f64, mut n: i32) -> f64 {
     let x1p1023 = f64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023
     let x1p53 = f64::from_bits(0x4340000000000000); // 0x1p53 === 2 ^ 53
     let x1p_1022 = f64::from_bits(0x0010000000000000); // 0x1p-1022 === 2 ^ (-1022)

--- a/src/math/scalbnf.rs
+++ b/src/math/scalbnf.rs
@@ -1,5 +1,5 @@
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn scalbnf(mut x: f32, mut n: i32) -> f32 {
+pub const fn scalbnf(mut x: f32, mut n: i32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127
     let x1p_126 = f32::from_bits(0x800000); // 0x1p-126f === 2 ^ -126
     let x1p24 = f32::from_bits(0x4b800000); // 0x1p24f === 2 ^ 24


### PR DESCRIPTION
**Update 2023-12-18**

This is still blocked by having these features not in stable.

```
#![feature(const_float_bits_conv)]
#![feature(const_fn_floating_point_arithmetic)]
#![feature(const_float_classify)]
```

---

This commit adds "const fn" where possible without major refactorings. All functions that rely on special LLVM runtime intrinsic (such as SSE) or `core::ptr::read_volatile` are untouched by this.

Currently, the CI does not pass. I'd like to know if you think this PR is beneficial at all. If so, we/I can work further on it. Currently, many functions can't be ported to be a "const fn" easily because many of them rely on `core::ptr::read_volatile` during runtime.

This will be breaking because it requires a recent rust nightly. Let me know what you think!