### PR TITLE
Ensure more functions do not panic

### DIFF
--- a/src/math/acosh.rs
+++ b/src/math/acosh.rs
@@ -7,6 +7,7 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 /// Calculates the inverse hyperbolic cosine of `x`.
 /// Is defined as `log(x + sqrt(x*x-1))`.
 /// `x` must be a number greater than or equal to 1.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn acosh(x: f64) -> f64 {
     let u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;

--- a/src/math/acoshf.rs
+++ b/src/math/acoshf.rs
@@ -7,6 +7,7 @@ const LN2: f32 = 0.693147180559945309417232121458176568;
 /// Calculates the inverse hyperbolic cosine of `x`.
 /// Is defined as `log(x + sqrt(x*x-1))`.
 /// `x` must be a number greater than or equal to 1.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn acoshf(x: f32) -> f32 {
     let u = x.to_bits();
     let a = u & 0x7fffffff;

--- a/src/math/asinh.rs
+++ b/src/math/asinh.rs
@@ -7,6 +7,7 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 ///
 /// Calculates the inverse hyperbolic sine of `x`.
 /// Is defined as `sgn(x)*log(|x|+sqrt(x*x+1))`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn asinh(mut x: f64) -> f64 {
     let mut u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;

--- a/src/math/asinhf.rs
+++ b/src/math/asinhf.rs
@@ -7,6 +7,7 @@ const LN2: f32 = 0.693147180559945309417232121458176568;
 ///
 /// Calculates the inverse hyperbolic sine of `x`.
 /// Is defined as `sgn(x)*log(|x|+sqrt(x*x+1))`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn asinhf(mut x: f32) -> f32 {
     let u = x.to_bits();
     let i = u & 0x7fffffff;

--- a/src/math/atanh.rs
+++ b/src/math/atanh.rs
@@ -5,6 +5,7 @@ use super::log1p;
 ///
 /// Calculates the inverse hyperbolic tangent of `x`.
 /// Is defined as `log((1+x)/(1-x))/2 = log1p(2x/(1-x))/2`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn atanh(x: f64) -> f64 {
     let u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;

--- a/src/math/atanhf.rs
+++ b/src/math/atanhf.rs
@@ -5,6 +5,7 @@ use super::log1pf;
 ///
 /// Calculates the inverse hyperbolic tangent of `x`.
 /// Is defined as `log((1+x)/(1-x))/2 = log1p(2x/(1-x))/2`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn atanhf(mut x: f32) -> f32 {
     let mut u = x.to_bits();
     let sign = (u >> 31) != 0;

--- a/src/math/copysign.rs
+++ b/src/math/copysign.rs
@@ -2,6 +2,7 @@
 ///
 /// Constructs a number with the magnitude (absolute value) of its
 /// first argument, `x`, and the sign of its second argument, `y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn copysign(x: f64, y: f64) -> f64 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();

--- a/src/math/copysignf.rs
+++ b/src/math/copysignf.rs
@@ -2,6 +2,7 @@
 ///
 /// Constructs a number with the magnitude (absolute value) of its
 /// first argument, `x`, and the sign of its second argument, `y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn copysignf(x: f32, y: f32) -> f32 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();

--- a/src/math/erf.rs
+++ b/src/math/erf.rs
@@ -219,6 +219,7 @@ fn erfc2(ix: u32, mut x: f64) -> f64 {
 /// Calculates an approximation to the “error function”, which estimates
 /// the probability that an observation will fall within x standard
 /// deviations of the mean (assuming a normal distribution).
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn erf(x: f64) -> f64 {
     let r: f64;
     let s: f64;

--- a/src/math/erff.rs
+++ b/src/math/erff.rs
@@ -130,6 +130,7 @@ fn erfc2(mut ix: u32, mut x: f32) -> f32 {
 /// Calculates an approximation to the “error function”, which estimates
 /// the probability that an observation will fall within x standard
 /// deviations of the mean (assuming a normal distribution).
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn erff(x: f32) -> f32 {
     let r: f32;
     let s: f32;

--- a/src/math/exp10.rs
+++ b/src/math/exp10.rs
@@ -6,16 +6,17 @@ const P10: &[f64] = &[
     1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
 ];
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp10(x: f64) -> f64 {
     let (mut y, n) = modf(x);
     let u: u64 = n.to_bits();
     /* fabs(n) < 16 without raising invalid on nan */
     if (u >> 52 & 0x7ff) < 0x3ff + 4 {
         if y == 0.0 {
-            return P10[((n as isize) + 15) as usize];
+            return i!(P10, ((n as isize) + 15) as usize);
         }
         y = exp2(LN10 * y);
-        return y * P10[((n as isize) + 15) as usize];
+        return y * i!(P10, ((n as isize) + 15) as usize);
     }
     return pow(10.0, x);
 }

--- a/src/math/exp10f.rs
+++ b/src/math/exp10f.rs
@@ -6,16 +6,17 @@ const P10: &[f32] = &[
     1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7,
 ];
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp10f(x: f32) -> f32 {
     let (mut y, n) = modff(x);
     let u = n.to_bits();
     /* fabsf(n) < 8 without raising invalid on nan */
     if (u >> 23 & 0xff) < 0x7f + 3 {
         if y == 0.0 {
-            return P10[((n as isize) + 7) as usize];
+            return i!(P10, ((n as isize) + 7) as usize);
         }
         y = exp2f(LN10_F32 * y);
-        return y * P10[((n as isize) + 7) as usize];
+        return y * i!(P10, ((n as isize) + 7) as usize);
     }
     return exp2(LN10_F64 * (x as f64)) as f32;
 }

--- a/src/math/ilogb.rs
+++ b/src/math/ilogb.rs
@@ -1,6 +1,7 @@
 const FP_ILOGBNAN: i32 = -1 - 0x7fffffff;
 const FP_ILOGB0: i32 = FP_ILOGBNAN;
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn ilogb(x: f64) -> i32 {
     let mut i: u64 = x.to_bits();
     let e = ((i >> 52) & 0x7ff) as i32;

--- a/src/math/ilogbf.rs
+++ b/src/math/ilogbf.rs
@@ -1,6 +1,7 @@
 const FP_ILOGBNAN: i32 = -1 - 0x7fffffff;
 const FP_ILOGB0: i32 = FP_ILOGBNAN;
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn ilogbf(x: f32) -> i32 {
     let mut i = x.to_bits();
     let e = ((i >> 23) & 0xff) as i32;

--- a/src/math/lgamma.rs
+++ b/src/math/lgamma.rs
@@ -1,5 +1,6 @@
 use super::lgamma_r;
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgamma(x: f64) -> f64 {
     lgamma_r(x).0
 }

--- a/src/math/lgamma_r.rs
+++ b/src/math/lgamma_r.rs
@@ -152,7 +152,7 @@ fn sin_pi(mut x: f64) -> f64 {
     x = 2.0 * (x * 0.5 - floor(x * 0.5)); /* x mod 2.0 */
 
     n = (x * 4.0) as i32;
-    n = (n + 1) / 2;
+    n = div!(n + 1, 2);
     x -= (n as f64) * 0.5;
     x *= PI;
 
@@ -164,6 +164,7 @@ fn sin_pi(mut x: f64) -> f64 {
     }
 }
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgamma_r(mut x: f64) -> (f64, i32) {
     let u: u64 = x.to_bits();
     let mut t: f64;

--- a/src/math/lgammaf.rs
+++ b/src/math/lgammaf.rs
@@ -1,5 +1,6 @@
 use super::lgammaf_r;
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgammaf(x: f32) -> f32 {
     lgammaf_r(x).0
 }

--- a/src/math/lgammaf_r.rs
+++ b/src/math/lgammaf_r.rs
@@ -88,7 +88,7 @@ fn sin_pi(mut x: f32) -> f32 {
     x = 2.0 * (x * 0.5 - floorf(x * 0.5)); /* x mod 2.0 */
 
     n = (x * 4.0) as isize;
-    n = (n + 1) / 2;
+    n = div!(n + 1, 2);
     y = (x as f64) - (n as f64) * 0.5;
     y *= 3.14159265358979323846;
     match n {
@@ -99,6 +99,7 @@ fn sin_pi(mut x: f32) -> f32 {
     }
 }
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgammaf_r(mut x: f32) -> (f32, i32) {
     let u = x.to_bits();
     let mut t: f32;

--- a/src/math/sincos.rs
+++ b/src/math/sincos.rs
@@ -12,6 +12,7 @@
 
 use super::{get_high_word, k_cos, k_sin, rem_pio2};
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sincos(x: f64) -> (f64, f64) {
     let s: f64;
     let c: f64;

--- a/src/math/sincosf.rs
+++ b/src/math/sincosf.rs
@@ -23,6 +23,7 @@ const S2PIO2: f32 = 2.0 * PI_2; /* 0x400921FB, 0x54442D18 */
 const S3PIO2: f32 = 3.0 * PI_2; /* 0x4012D97C, 0x7F3321D2 */
 const S4PIO2: f32 = 4.0 * PI_2; /* 0x401921FB, 0x54442D18 */
 
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sincosf(x: f32) -> (f32, f32) {
     let s: f32;
     let c: f32;


### PR DESCRIPTION
This PR:

- adds `#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]` to more functions
- removes panics from `exp10` and `exp10f`

This leaves `frexp` and `frexpf` as the only remaining functions that can panic (wasn't able to figure out how to fix).

Edit: it looks like `j1f` (and possibly `j1` can also panic)

Edit 2: Not sure why, but it looks like the tests didn't catch [integer division](https://github.com/rust-lang/libm/blob/d6d8a1610c9912c84c4c1d12d994d0204dc702ef/src/math/lgamma_r.rs#L155) in `lgamma_r`/`lgammaf_r`