### PR TITLE
Add a small conformance test to sqrt/sqrtf

### DIFF
--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -261,16 +261,20 @@ mod tests {
             assert_eq!(sqrt(f), f);
         }
     }
-    
+
     #[test]
     fn conformance_tests() {
         let values = [3.14159265359, 10000.0, f64::from_bits(0x0000000f), INFINITY];
-        let results = [4610661241675116657u64, 4636737291354636288u64,
-        2197470602079456986u64, 9218868437227405312u64];
-        
+        let results = [
+            4610661241675116657u64,
+            4636737291354636288u64,
+            2197470602079456986u64,
+            9218868437227405312u64,
+        ];
+
         for i in 0..values.len() {
             let bits = f64::to_bits(sqrt(values[i]));
             assert_eq!(results[i], bits);
-        } 
+        }
     }
 }

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -261,4 +261,16 @@ mod tests {
             assert_eq!(sqrt(f), f);
         }
     }
+    
+    #[test]
+    fn conformance_tests() {
+        let values = [3.14159265359, 10000.0, -1.0, INFINITY];
+        let results = [4610661241675116657u64, 4636737291354636288u64,
+        18444492273895866368u64, 9218868437227405312u64];
+        
+        for i in 0..values.len() {
+            let bits = f64::to_bits(sqrt(values[i]));
+            assert_eq!(results[i], bits);
+        } 
+    }
 }

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -264,9 +264,9 @@ mod tests {
     
     #[test]
     fn conformance_tests() {
-        let values = [3.14159265359, 10000.0, -1.0, INFINITY];
+        let values = [3.14159265359, 10000.0, f64::from_bits(0x0000000f), INFINITY];
         let results = [4610661241675116657u64, 4636737291354636288u64,
-        18444492273895866368u64, 9218868437227405312u64];
+        2197470602079456986u64, 9218868437227405312u64];
         
         for i in 0..values.len() {
             let bits = f64::to_bits(sqrt(values[i]));

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -154,9 +154,9 @@ mod tests {
     
      #[test]
     fn conformance_tests() {
-        let values = [3.14159265359f32, 10000.0f32, -1.0f32, INFINITY];
-        let results = [1071833029u32, 1120403456u32, 4290772992u32, 2139095040u32];
-        
+        let values = [3.14159265359f32, 10000.0f32, f32::from_bits(0x0000000f), INFINITY];
+        let results = [1071833029u32, 1120403456u32, 456082799u32, 2139095040u32];
+
         for i in 0..values.len() {
             let bits = f32::to_bits(sqrtf(values[i]));
             assert_eq!(results[i], bits);

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -151,15 +151,20 @@ mod tests {
             assert_eq!(sqrtf(f), f);
         }
     }
-    
-     #[test]
+
+    #[test]
     fn conformance_tests() {
-        let values = [3.14159265359f32, 10000.0f32, f32::from_bits(0x0000000f), INFINITY];
+        let values = [
+            3.14159265359f32,
+            10000.0f32,
+            f32::from_bits(0x0000000f),
+            INFINITY,
+        ];
         let results = [1071833029u32, 1120403456u32, 456082799u32, 2139095040u32];
 
         for i in 0..values.len() {
             let bits = f32::to_bits(sqrtf(values[i]));
             assert_eq!(results[i], bits);
-        } 
+        }
     }
 }

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -151,4 +151,15 @@ mod tests {
             assert_eq!(sqrtf(f), f);
         }
     }
+    
+     #[test]
+    fn conformance_tests() {
+        let values = [3.14159265359f32, 10000.0f32, -1.0f32, INFINITY];
+        let results = [1071833029u32, 1120403456u32, 4290772992u32, 2139095040u32];
+        
+        for i in 0..values.len() {
+            let bits = f32::to_bits(sqrtf(values[i]));
+            assert_eq!(results[i], bits);
+        } 
+    }
 }


### PR DESCRIPTION
**What this PR does**

Add a test that guarantees that the result of sqrt/sqrtf is bit for bit identical on all platforms for a given array of test values.

**Why this PR**

This is a proposed fix for issue #255. Which asks all sqrt implementations to be IEEE 754 2008 compliant. While this does not prove compliance with the spec it at least proves conformance between platforms.

**Issues with this PR**

Since the values and their results are hard coded, they would need to be updated on every implementation change. The values are also somewhat arbitrary and don't cover every case inside the sqrt implementation.

Any feedback is very welcome.
