### PR TITLE
Fix descriptions of erfc and erfcf

### DIFF
--- a/src/math/erf.rs
+++ b/src/math/erf.rs
@@ -263,7 +263,7 @@ pub fn erf(x: f64) -> f64 {
     }
 }
 
-/// Error function (f64)
+/// Complementary error function (f64)
 ///
 /// Calculates the complementary probability.
 /// Is `1 - erf(x)`. Is computed directly, so that you can use it to avoid

--- a/src/math/erff.rs
+++ b/src/math/erff.rs
@@ -174,7 +174,7 @@ pub fn erff(x: f32) -> f32 {
     }
 }
 
-/// Error function (f32)
+/// Complementary error function (f32)
 ///
 /// Calculates the complementary probability.
 /// Is `1 - erf(x)`. Is computed directly, so that you can use it to avoid


### PR DESCRIPTION
As described in the second paragraph of the docs for these functions, they are the complementary error function, not the error function. See https://en.wikipedia.org/wiki/Error_function for the name "complementary error function".