### PR TITLE
Fix rint and rintf on x87.

### DIFF
--- a/src/math/rint.rs
+++ b/src/math/rint.rs
@@ -8,9 +8,19 @@ pub fn rint(x: f64) -> f64 {
         x
     } else {
         let ans = if is_positive {
-            x + one_over_e - one_over_e
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let x = force_eval!(x);
+            let xplusoneovere = x + one_over_e;
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let xplusoneovere = force_eval!(xplusoneovere);
+            xplusoneovere - one_over_e
         } else {
-            x - one_over_e + one_over_e
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let x = force_eval!(x);
+            let xminusoneovere = x - one_over_e;
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let xminusoneovere = force_eval!(xminusoneovere);
+            xminusoneovere + one_over_e
         };
 
         if ans == 0.0 {

--- a/src/math/rintf.rs
+++ b/src/math/rintf.rs
@@ -8,9 +8,19 @@ pub fn rintf(x: f32) -> f32 {
         x
     } else {
         let ans = if is_positive {
-            x + one_over_e - one_over_e
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let x = force_eval!(x);
+            let xplusoneovere = x + one_over_e;
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let xplusoneovere = force_eval!(xplusoneovere);
+            xplusoneovere - one_over_e
         } else {
-            x - one_over_e + one_over_e
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let x = force_eval!(x);
+            let xminusoneovere = x - one_over_e;
+            #[cfg(all(target_arch = "x86", not(target_feature = "sse2")))]
+            let xminusoneovere = force_eval!(xminusoneovere);
+            xminusoneovere + one_over_e
         };
 
         if ans == 0.0 {


### PR DESCRIPTION
While working on updating the libm crate in Debian I ran into a test failure on Debian i386.

    ---- math::rintf::tests::sanity_check stdout ----
    thread 'math::rintf::tests::sanity_check' panicked at 'assertion failed: `(left == right)`
      left: `2.8`,
     right: `3.0`', src/math/rintf.rs:42:9
    
    ---- math::rint::tests::sanity_check stdout ----
    thread 'math::rint::tests::sanity_check' panicked at 'assertion failed: `(left == right)`
      left: `2.7998046875`,
     right: `3.0`', src/math/rint.rs:42:9
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Debian i386 uses the x87 FPU. The x87 FPU suffers from excess precision, where intermediate values are calculated in a higher precsion than their nominal data types can store. Most of the time this results in the results of calculations being slightly more accurate than expected, but when code tries to play tricks with rounding it can result in massively incorrect results.

To work around this, the libm crate contains a force_eval! macro which forces the value to be stored to memory and hence forces it to be rounded to it's nominal data type. This macro is used in a number of places where we need to ensure values are correctly rounded to their nominal format. This was implemented by my previous accepted pull request. https://github.com/rust-lang/libm/pull/249

However since that was implemented, two new functions rint and rintf were added. These did not take any steps to force rounding to the storage format and hence fail on x87. This PR implements forced rounding in those functions on x87. On other architectures it should be a no-op.



