### PR TITLE
This updates the exponent calculations done in the nextafter functions to match their MUSL counterparts

### DIFF
--- a/src/math/nextafter.rs
+++ b/src/math/nextafter.rs
@@ -23,7 +23,7 @@ pub fn nextafter(x: f64, y: f64) -> f64 {
         ux_i += 1;
     }
 
-    let e = ux_i.wrapping_shr(52 & 0x7ff);
+    let e = ux_i >> 52 & 0x7ff;
     // raise overflow if ux.f is infinite and x is finite
     if e == 0x7ff {
         force_eval!(x + x);

--- a/src/math/nextafterf.rs
+++ b/src/math/nextafterf.rs
@@ -23,7 +23,7 @@ pub fn nextafterf(x: f32, y: f32) -> f32 {
         ux_i += 1;
     }
 
-    let e = ux_i.wrapping_shr(0x7f80_0000_u32);
+    let e = ux_i & 0x7f80_0000_u32;
     // raise overflow if ux_f is infinite and x is finite
     if e == 0x7f80_0000_u32 {
         force_eval!(x + x);


### PR DESCRIPTION
Hello,

As detailed in #286, the nextafter family of functions incorrectly computes exponents, leading to potential missed underflow/overflow signals relative to the MUSL implementations. This updates these calculations to match the calculations as found in the MUSL implementations. I don't know how to write a test for these changes without access to the floating point environment.

Thanks,
Mark

Fixes #286