### PR TITLE
Remove unneeded `extern core` in `tgamma`

### DIFF
--- a/src/math/tgamma.rs
+++ b/src/math/tgamma.rs
@@ -22,7 +22,6 @@ Gamma(x)*Gamma(-x) = -pi/(x sin(pi x))
 
 most ideas and constants are from boost and python
 */
-extern crate core;
 use super::{exp, floor, k_cos, k_sin, pow};
 
 const PI: f64 = 3.141592653589793238462643383279502884;


### PR DESCRIPTION
This was causing some issues when building the crate for different targets that don't have `core` builtin.