### PR TITLE
Compiling `libm` for `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ version = "0.2.8"
 edition = "2018"
 exclude = ["/ci/", "/.github/workflows/"]
 
+[dependencies]
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = '0.1.2', optional = true }
+
 [features]
 default = []
 
@@ -22,6 +28,11 @@ unstable = []
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
 musl-reference-tests = ['rand']
+
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'compiler_builtins']
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     #[cfg(feature = "musl-reference-tests")]
     musl_reference_tests::generate();
 
-    if !cfg!(feature = "checked") {
+    if !cfg!(debug_assertions) {
         let lvl = env::var("OPT_LEVEL").unwrap();
         if lvl != "0" {
             println!("cargo:rustc-cfg=assert_no_panic");

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,11 @@ fn main() {
             println!("cargo:rustc-cfg=assert_no_panic");
         }
     }
+    // add cfg flags to suppress warnings generated from compiling `std` specifically
+    if cfg!(feature = "rustc-dep-of-std") {
+        println!("cargo:rustc-check-cfg=cfg(rustfmt)");
+        println!("cargo:rustc-check-cfg=cfg(assert_no_panic)");
+    }
 }
 
 #[cfg(feature = "musl-reference-tests")]

--- a/src/math/rem_pio2_large.rs
+++ b/src/math/rem_pio2_large.rs
@@ -227,7 +227,7 @@ pub(crate) fn rem_pio2_large(x: &[f64], y: &mut [f64], e0: i32, prec: usize) -> 
     let x1p24 = f64::from_bits(0x4170000000000000); // 0x1p24 === 2 ^ 24
     let x1p_24 = f64::from_bits(0x3e70000000000000); // 0x1p_24 === 2 ^ (-24)
 
-    #[cfg(all(target_pointer_width = "64", feature = "checked"))]
+    #[cfg(all(target_pointer_width = "64", debug_assertions))]
     assert!(e0 <= 16360);
 
     let nx = x.len();

--- a/src/math/tgamma.rs
+++ b/src/math/tgamma.rs
@@ -22,7 +22,6 @@ Gamma(x)*Gamma(-x) = -pi/(x sin(pi x))
 
 most ideas and constants are from boost and python
 */
-extern crate core;
 use super::{exp, floor, k_cos, k_sin, pow};
 
 const PI: f64 = 3.141592653589793238462643383279502884;


### PR DESCRIPTION
Added the ability to compile `libm` as a child dependency of `std`.

This will allow fixing the issue where some targets that don't have `libc` linked can have math functions without linking errors.

This fixes the issue originating in https://github.com/rust-lang/compiler-builtins/issues/576

This also replaces #289 as its included in this one.