### PR TITLE
Enable PowerPC tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -61,12 +61,6 @@ mod musl_reference_tests {
     }
 
     pub fn generate() {
-        // PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-        if target_arch == "powerpc64" {
-            return;
-        }
-
         let files = fs::read_dir("src/math")
             .unwrap()
             .map(|f| f.unwrap().path())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,5 @@ pub fn _eq(a: f64, b: f64) -> Result<(), u64> {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(all(test, feature = "musl-reference-tests"))]
 include!(concat!(env!("OUT_DIR"), "/musl-tests.rs"));

--- a/src/math/ceilf.rs
+++ b/src/math/ceilf.rs
@@ -40,8 +40,6 @@ pub fn ceilf(x: f32) -> f32 {
     f32::from_bits(ui)
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -14,8 +14,6 @@ pub fn fabsf(x: f32) -> f32 {
     f32::from_bits(x.to_bits() & 0x7fffffff)
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -40,8 +40,6 @@ pub fn floorf(x: f32) -> f32 {
     f32::from_bits(ui)
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -357,8 +357,6 @@ fn qonef(x: f32) -> f32 {
     return (0.375 + r / s) / x;
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::{j1f, y1f};

--- a/src/math/rint.rs
+++ b/src/math/rint.rs
@@ -35,8 +35,6 @@ pub fn rint(x: f64) -> f64 {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::rint;

--- a/src/math/rintf.rs
+++ b/src/math/rintf.rs
@@ -35,8 +35,6 @@ pub fn rintf(x: f32) -> f32 {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::rintf;

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -7,8 +7,6 @@ pub fn roundf(x: f32) -> f32 {
     truncf(x + copysignf(0.5 - 0.25 * f32::EPSILON, x))
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::roundf;

--- a/src/math/sincosf.rs
+++ b/src/math/sincosf.rs
@@ -123,8 +123,6 @@ pub fn sincosf(x: f32) -> (f32, f32) {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::sincosf;

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -128,8 +128,6 @@ pub fn sqrtf(x: f32) -> f32 {
     }
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -31,8 +31,6 @@ pub fn truncf(x: f32) -> f32 {
     f32::from_bits(i)
 }
 
-// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
-#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
The oldest LLVM we support is now 16. Do these tests pass now?