### PR TITLE
`TotalEq` -0 in `fabs` test

### DIFF
--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -32,7 +32,7 @@ mod tests {
     fn spec_tests() {
         assert!(fabs(NAN).is_nan());
         for f in [0.0, -0.0].iter().copied() {
-            assert_eq!(fabs(f), 0.0);
+            assert_eq!(fabs(f).total_cmp(&0.0), core::cmp::Ordering::Equal);
         }
         for f in [INFINITY, NEG_INFINITY].iter().copied() {
             assert_eq!(fabs(f), INFINITY);


### PR DESCRIPTION
`assert_eq!` uses `PartialEq`, which doesn't discern between -0 and +0. `total_cmp` does distinguish them. So this patch makes the test spec-compliant