### PR TITLE
Fix `clippy::deprecated_cfg_attr` on compiler_builtins

### DIFF
--- a/src/math/exp2.rs
+++ b/src/math/exp2.rs
@@ -28,7 +28,7 @@ use super::scalbn;
 
 const TBLSIZE: usize = 256;
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static TBL: [u64; TBLSIZE * 2] = [
     //  exp2(z + eps)          eps
     0x3fe6a09e667f3d5d, 0x3d39880000000000,


### PR DESCRIPTION
Fixes issue rising from `libm` when running `clippy`.

Related to https://github.com/rust-lang/compiler-builtins/pull/594

--

Beside this change, this crate contain a lot of clippy warnings, relating to floating precision and the usage of `0 / (n - n)` expressions. most are fixed by `clippy --fix`.

I didn't add those, since these implementations seemed to be copy-pasted from somewhere else, but let me know if it would better to also add those clippy fixes.