### PR TITLE
Deny warnings in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 on: [push, pull_request]
 
+env:
+  RUSTDOCFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   docker:
     name: Docker

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,14 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo::rustc-check-cfg=cfg(assert_no_panic)");
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"unstable\"))");
 
     #[cfg(feature = "musl-reference-tests")]
     musl_reference_tests::generate();
 
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"checked\"))");
+    #[allow(unexpected_cfgs)]
     if !cfg!(feature = "checked") {
         let lvl = env::var("OPT_LEVEL").unwrap();
         if lvl != "0" {

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -16,6 +16,7 @@ run() {
     docker run \
            --rm \
            --user $(id -u):$(id -g) \
+           -e RUSTFLAGS \
            -e CARGO_HOME=/cargo \
            -e CARGO_TARGET_DIR=/target \
            -v "${HOME}/.cargo":/cargo \

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["Jorge Aparicio <jorge@japaric.io>"]
 test = false
 bench = false
 
+[features]
+unstable = []
+checked = []

--- a/crates/compiler-builtins-smoke-test/build.rs
+++ b/crates/compiler-builtins-smoke-test/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(assert_no_panic)");
+}

--- a/crates/compiler-builtins-smoke-test/src/lib.rs
+++ b/crates/compiler-builtins-smoke-test/src/lib.rs
@@ -6,4 +6,4 @@
 #![no_std]
 
 #[path = "../../../src/math/mod.rs"]
-mod libm;
+pub mod libm;


### PR DESCRIPTION
The main crate already has `#![deny(warnings)]`. Set RUSTFLAGS in CI to enforce this for other crates in the workspace.