### PR TITLE
Add `force-soft-floats` feature to prevent using any intrinsics or arch-specific code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ unstable = []
 # musl libc.
 musl-reference-tests = ['rand']
 
+# Used to prevent using any intrinsics or arch-specific code.
+only-soft-floats = []
+
 [workspace]
 members = [
   "crates/compiler-builtins-smoke-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ unstable = []
 musl-reference-tests = ['rand']
 
 # Used to prevent using any intrinsics or arch-specific code.
-only-soft-floats = []
+force-soft-floats = []
 
 [workspace]
 members = [

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -10,4 +10,4 @@ bench = false
 [features]
 unstable = []
 checked = []
-only-soft-floats = []
+force-soft-floats = []

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -10,3 +10,4 @@ bench = false
 [features]
 unstable = []
 checked = []
+only-soft-floats = []

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -76,7 +76,7 @@ macro_rules! div {
 
 macro_rules! llvm_intrinsically_optimized {
     (#[cfg($($clause:tt)*)] $e:expr) => {
-        #[cfg(all(feature = "unstable", not(feature = "only-soft-floats"), $($clause)*))]
+        #[cfg(all(feature = "unstable", not(feature = "force-soft-floats"), $($clause)*))]
         {
             if true { // thwart the dead code lint
                 $e

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -76,7 +76,7 @@ macro_rules! div {
 
 macro_rules! llvm_intrinsically_optimized {
     (#[cfg($($clause:tt)*)] $e:expr) => {
-        #[cfg(all(feature = "unstable", $($clause)*))]
+        #[cfg(all(feature = "unstable", not(feature = "only-soft-floats"), $($clause)*))]
         {
             if true { // thwart the dead code lint
                 $e

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -92,7 +92,7 @@ pub fn sqrt(x: f64) -> f64 {
             }
         }
     }
-    #[cfg(target_feature = "sse2")]
+    #[cfg(all(target_feature = "sse2", not(feature = "only-soft-floats")))]
     {
         // Note: This path is unlikely since LLVM will usually have already
         // optimized sqrt calls into hardware instructions if sse2 is available,
@@ -107,7 +107,7 @@ pub fn sqrt(x: f64) -> f64 {
             _mm_cvtsd_f64(m_sqrt)
         }
     }
-    #[cfg(not(target_feature = "sse2"))]
+    #[cfg(any(not(target_feature = "sse2"), feature = "only-soft-floats"))]
     {
         use core::num::Wrapping;
 

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -92,7 +92,7 @@ pub fn sqrt(x: f64) -> f64 {
             }
         }
     }
-    #[cfg(all(target_feature = "sse2", not(feature = "only-soft-floats")))]
+    #[cfg(all(target_feature = "sse2", not(feature = "force-soft-floats")))]
     {
         // Note: This path is unlikely since LLVM will usually have already
         // optimized sqrt calls into hardware instructions if sse2 is available,
@@ -107,7 +107,7 @@ pub fn sqrt(x: f64) -> f64 {
             _mm_cvtsd_f64(m_sqrt)
         }
     }
-    #[cfg(any(not(target_feature = "sse2"), feature = "only-soft-floats"))]
+    #[cfg(any(not(target_feature = "sse2"), feature = "force-soft-floats"))]
     {
         use core::num::Wrapping;
 

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -27,7 +27,7 @@ pub fn sqrtf(x: f32) -> f32 {
             }
         }
     }
-    #[cfg(all(target_feature = "sse", not(feature = "only-soft-floats")))]
+    #[cfg(all(target_feature = "sse", not(feature = "force-soft-floats")))]
     {
         // Note: This path is unlikely since LLVM will usually have already
         // optimized sqrt calls into hardware instructions if sse is available,
@@ -42,7 +42,7 @@ pub fn sqrtf(x: f32) -> f32 {
             _mm_cvtss_f32(m_sqrt)
         }
     }
-    #[cfg(any(not(target_feature = "sse"), feature = "only-soft-floats"))]
+    #[cfg(any(not(target_feature = "sse"), feature = "force-soft-floats"))]
     {
         const TINY: f32 = 1.0e-30;
 

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -27,7 +27,7 @@ pub fn sqrtf(x: f32) -> f32 {
             }
         }
     }
-    #[cfg(target_feature = "sse")]
+    #[cfg(all(target_feature = "sse", not(feature = "only-soft-floats")))]
     {
         // Note: This path is unlikely since LLVM will usually have already
         // optimized sqrt calls into hardware instructions if sse is available,
@@ -42,7 +42,7 @@ pub fn sqrtf(x: f32) -> f32 {
             _mm_cvtss_f32(m_sqrt)
         }
     }
-    #[cfg(not(target_feature = "sse"))]
+    #[cfg(any(not(target_feature = "sse"), feature = "only-soft-floats"))]
     {
         const TINY: f32 = 1.0e-30;
 


### PR DESCRIPTION
It comes from this [zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Infinite.20recursion.20in.20compiler-builtins) which is blocking the last GCC backend sync with rustc.

cc @Amanieu 