### PR TITLE
Rename the `musl-reference-tests` feature to `musl-bitwise-tests`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
   in `src/lib.rs`.
 - Write some simple tests in your module (using `#[test]`)
 - Run `cargo test` to make sure it works
-- Run `cargo test --features libm-test/musl-reference-tests` to compare your
+- Run `cargo test --features libm-test/musl-bitwise-tests` to compare your
   implementation against musl's
 - Send us a pull request! Make sure to run `cargo fmt` on your code before
   sending the PR. Also include "closes #42" in the PR description to close the
@@ -88,7 +88,7 @@ If you'd like to run tests with randomized inputs that get compared against musl
 itself, you'll need to be on a Linux system and then you can execute:
 
 ```
-cargo test --features libm-test/musl-reference-tests
+cargo test --features libm-test/musl-bitwise-tests
 ```
 
 Note that you may need to pass `--release` to Cargo if there are errors related

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -17,5 +17,5 @@ $cmd --features 'unstable'
 $cmd --release --features 'unstable'
 
 # also run the reference tests
-$cmd --features 'unstable libm-test/musl-reference-tests'
-$cmd --release --features 'unstable libm-test/musl-reference-tests'
+$cmd --features 'unstable libm-test/musl-bitwise-tests'
+$cmd --release --features 'unstable libm-test/musl-bitwise-tests'

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
-musl-reference-tests = ["rand"]
+musl-bitwise-tests = ["rand"]
 
 [dependencies]
 libm = { path = "../.." }

--- a/crates/libm-test/build.rs
+++ b/crates/libm-test/build.rs
@@ -1,9 +1,9 @@
 fn main() {
-    #[cfg(feature = "musl-reference-tests")]
+    #[cfg(feature = "musl-bitwise-tests")]
     musl_reference_tests::generate();
 }
 
-#[cfg(feature = "musl-reference-tests")]
+#[cfg(feature = "musl-bitwise-tests")]
 mod musl_reference_tests {
     use rand::seq::SliceRandom;
     use rand::Rng;

--- a/crates/libm-test/tests/musl_biteq.rs
+++ b/crates/libm-test/tests/musl_biteq.rs
@@ -1,4 +1,6 @@
+//! compare
+
 // PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
 #[cfg(not(target_arch = "powerpc64"))]
-#[cfg(all(test, feature = "musl-reference-tests"))]
+#[cfg(all(test, feature = "musl-bitwise-tests"))]
 include!(concat!(env!("OUT_DIR"), "/musl-tests.rs"));


### PR DESCRIPTION
The plan is to add more test related features that could be considered "reference tests". Rename the feature here to avoid future confusion.