### PR TITLE
Set target-specific `AR` and `CC` arguments

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -5,7 +5,11 @@ RUN apt-get update && \
     gcc libc6-dev ca-certificates \
     gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
     qemu-user-static
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+
+ENV TOOLCHAIN_PREFIX=aarch64-linux-gnu-
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=qemu-aarch64-static \
+    AR_aarch64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
+    CC_aarch64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -4,7 +4,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \
     gcc-arm-linux-gnueabi libc6-dev-armel-cross qemu-user-static
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
+
+ENV TOOLCHAIN_PREFIX=arm-linux-gnueabi-
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_RUNNER=qemu-arm-static \
+    AR_arm_unknown_linux_gnueabi="$TOOLCHAIN_PREFIX"ar \
+    CC_arm_unknown_linux_gnueabi="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
     RUST_TEST_THREADS=1

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -4,7 +4,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \
     gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+
+ENV TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm-static \
+    AR_arm_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"ar \
+    CC_arm_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -4,7 +4,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev ca-certificates \
     gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
-ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+
+ENV TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER=qemu-arm-static \
+    AR_armv7_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"ar \
+    CC_armv7_unknown_linux_gnueabihf="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
     RUST_TEST_THREADS=1

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && \
     gcc-mips-linux-gnu libc6-dev-mips-cross \
     binfmt-support qemu-user-static qemu-system-mips
 
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
+ENV TOOLCHAIN_PREFIX=mips-linux-gnu-
+ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER=qemu-mips-static \
+    AR_mips_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
+    CC_mips_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/mips-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -9,8 +9,11 @@ RUN apt-get update && \
     libc6-dev-mips64-cross \
     qemu-user-static \
     qemu-system-mips
-ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
+
+ENV TOOLCHAIN_PREFIX=mips64-linux-gnuabi64-
+ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64-static \
-    CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
+    AR_mips64_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"ar \
+    CC_mips64_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \
     RUST_TEST_THREADS=1

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -8,8 +8,11 @@ RUN apt-get update && \
     libc6-dev \
     libc6-dev-mips64el-cross \
     qemu-user-static
-ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-gcc \
+
+ENV TOOLCHAIN_PREFIX=mips64el-linux-gnuabi64-
+ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER=qemu-mips64el-static \
-    CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc \
+    AR_mips64el_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"ar \
+    CC_mips64el_unknown_linux_gnuabi64="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64 \
     RUST_TEST_THREADS=1

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && \
     gcc-mipsel-linux-gnu libc6-dev-mipsel-cross \
     binfmt-support qemu-user-static
 
-ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
+ENV TOOLCHAIN_PREFIX=mipsel-linux-gnu-
+ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER=qemu-mipsel-static \
+    AR_mipsel_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
+    CC_mipsel_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && \
     gcc-powerpc-linux-gnu libc6-dev-powerpc-cross \
     qemu-system-ppc
 
-ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
+ENV TOOLCHAIN_PREFIX=powerpc-linux-gnu-
+ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc-static \
+    AR_powerpc_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
+    CC_powerpc_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get update && \
     gcc-powerpc64-linux-gnu libc6-dev-ppc64-cross \
     binfmt-support qemu-user-static qemu-system-ppc
 
-ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
+ENV TOOLCHAIN_PREFIX=powerpc64-linux-gnu-
+ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64-static \
-    CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
+    AR_powerpc64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
+    CC_powerpc64_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
     QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -6,8 +6,11 @@ RUN apt-get update && \
     gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross \
     qemu-system-ppc
 
-ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
+ENV TOOLCHAIN_PREFIX=powerpc64le-linux-gnu-
+ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER="$TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64le-static \
+    AR_powerpc64le_unknown_linux_gnu="$TOOLCHAIN_PREFIX"ar \
+    CC_powerpc64le_unknown_linux_gnu="$TOOLCHAIN_PREFIX"gcc \
     QEMU_CPU=POWER8 \
     QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
     RUST_TEST_THREADS=1


### PR DESCRIPTION
The Rust `cc` crate reads these, so make sure they are set for when we start making use of `cc`.