### PR TITLE
Rename the `musl-bitwise-tests` feature to `test-musl-serialized`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
   in `src/lib.rs`.
 - Write some simple tests in your module (using `#[test]`)
 - Run `cargo test` to make sure it works
-- Run `cargo test --features libm-test/musl-bitwise-tests` to compare your
+- Run `cargo test --features libm-test/test-musl-serialized` to compare your
   implementation against musl's
 - Send us a pull request! Make sure to run `cargo fmt` on your code before
   sending the PR. Also include "closes #42" in the PR description to close the
@@ -80,15 +80,15 @@ let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 12
 
 Normal tests can be executed with:
 
-```
+```sh
 cargo test
 ```
 
 If you'd like to run tests with randomized inputs that get compared against musl
 itself, you'll need to be on a Linux system and then you can execute:
 
-```
-cargo test --features libm-test/musl-bitwise-tests
+```sh
+cargo test --features libm-test/test-musl-serialized
 ```
 
 Note that you may need to pass `--release` to Cargo if there are errors related

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -18,5 +18,5 @@ $cmd --features 'unstable'
 $cmd --release --features 'unstable'
 
 # also run the reference tests
-$cmd --features 'unstable libm-test/musl-bitwise-tests'
-$cmd --release --features 'unstable libm-test/musl-bitwise-tests'
+$cmd --features 'unstable libm-test/test-musl-serialized'
+$cmd --release --features 'unstable libm-test/test-musl-serialized'

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
-musl-bitwise-tests = ["rand"]
+test-musl-serialized = ["rand"]
 
 [dependencies]
 libm = { path = "../.." }

--- a/crates/libm-test/build.rs
+++ b/crates/libm-test/build.rs
@@ -1,9 +1,9 @@
 fn main() {
-    #[cfg(feature = "musl-bitwise-tests")]
+    #[cfg(feature = "test-musl-serialized")]
     musl_reference_tests::generate();
 }
 
-#[cfg(feature = "musl-bitwise-tests")]
+#[cfg(feature = "test-musl-serialized")]
 mod musl_reference_tests {
     use rand::seq::SliceRandom;
     use rand::Rng;

--- a/crates/libm-test/tests/musl_biteq.rs
+++ b/crates/libm-test/tests/musl_biteq.rs
@@ -2,5 +2,5 @@
 
 // PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
 #[cfg(not(target_arch = "powerpc64"))]
-#[cfg(all(test, feature = "musl-bitwise-tests"))]
+#[cfg(all(test, feature = "test-musl-serialized"))]
 include!(concat!(env!("OUT_DIR"), "/musl-tests.rs"));


### PR DESCRIPTION
We will have more test features in the near future, and it would be nice for them all to have a common `test-` prefix. Reverse the existing feature so this is the case.