### PR TITLE
Add `copysignf16`, `copysignf128`, `fabsf16`, and `fabsf128`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ arch = []
 
 # This tells the compiler to assume that a Nightly toolchain is being used and
 # that it should activate any useful Nightly things accordingly.
-unstable = ["unstable-intrinsics"]
+unstable = ["unstable-intrinsics", "unstable-float"]
 
 # Enable calls to functions in `core::intrinsics`
 unstable-intrinsics = []
 
 # Make some internal things public for testing.
 unstable-test-support = []
+
+# Enable the nightly-only `f16` and `f128`.
+unstable-float = []
 
 # Used to prevent using any intrinsics or arch-specific code.
 #

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
 use std::env;
 
+mod configure;
+
 fn main() {
+    let cfg = configure::Config::from_env();
+
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(assert_no_panic)");
 
@@ -14,29 +18,5 @@ fn main() {
         }
     }
 
-    configure_intrinsics();
-    configure_arch();
-}
-
-/// Simplify the feature logic for enabling intrinsics so code only needs to use
-/// `cfg(intrinsics_enabled)`.
-fn configure_intrinsics() {
-    println!("cargo:rustc-check-cfg=cfg(intrinsics_enabled)");
-
-    // Disabled by default; `unstable-intrinsics` enables again; `force-soft-floats` overrides
-    // to disable.
-    if cfg!(feature = "unstable-intrinsics") && !cfg!(feature = "force-soft-floats") {
-        println!("cargo:rustc-cfg=intrinsics_enabled");
-    }
-}
-
-/// Simplify the feature logic for enabling arch-specific features so code only needs to use
-/// `cfg(arch_enabled)`.
-fn configure_arch() {
-    println!("cargo:rustc-check-cfg=cfg(arch_enabled)");
-
-    // Enabled by default via the "arch" feature, `force-soft-floats` overrides to disable.
-    if cfg!(feature = "arch") && !cfg!(feature = "force-soft-floats") {
-        println!("cargo:rustc-cfg=arch_enabled");
-    }
+    configure::emit_libm_config(&cfg);
 }

--- a/configure.rs
+++ b/configure.rs
@@ -1,0 +1,168 @@
+// Configuration shared with both libm and libm-test
+
+use std::env;
+use std::path::PathBuf;
+
+#[allow(dead_code)]
+pub struct Config {
+    pub manifest_dir: PathBuf,
+    pub out_dir: PathBuf,
+    pub opt_level: u8,
+    pub target_arch: String,
+    pub target_env: String,
+    pub target_family: Option<String>,
+    pub target_os: String,
+    pub target_string: String,
+    pub target_vendor: String,
+    pub target_features: Vec<String>,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        let target_features = env::var("CARGO_CFG_TARGET_FEATURE")
+            .map(|feats| feats.split(',').map(ToOwned::to_owned).collect())
+            .unwrap_or_default();
+
+        Self {
+            manifest_dir: PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()),
+            out_dir: PathBuf::from(env::var("OUT_DIR").unwrap()),
+            opt_level: env::var("OPT_LEVEL").unwrap().parse().unwrap(),
+            target_arch: env::var("CARGO_CFG_TARGET_ARCH").unwrap(),
+            target_env: env::var("CARGO_CFG_TARGET_ENV").unwrap(),
+            target_family: env::var("CARGO_CFG_TARGET_FAMILY").ok(),
+            target_os: env::var("CARGO_CFG_TARGET_OS").unwrap(),
+            target_string: env::var("TARGET").unwrap(),
+            target_vendor: env::var("CARGO_CFG_TARGET_VENDOR").unwrap(),
+            target_features,
+        }
+    }
+}
+
+/// Libm gets most config options made available.
+#[allow(dead_code)]
+pub fn emit_libm_config(cfg: &Config) {
+    emit_intrinsics_cfg();
+    emit_arch_cfg();
+    emit_optimization_cfg(cfg);
+    emit_cfg_shorthands(cfg);
+    emit_f16_f128_cfg(cfg);
+}
+
+/// Tests don't need most feature-related config.
+#[allow(dead_code)]
+pub fn emit_test_config(cfg: &Config) {
+    emit_optimization_cfg(cfg);
+    emit_cfg_shorthands(cfg);
+    emit_f16_f128_cfg(cfg);
+}
+
+/// Simplify the feature logic for enabling intrinsics so code only needs to use
+/// `cfg(intrinsics_enabled)`.
+fn emit_intrinsics_cfg() {
+    println!("cargo:rustc-check-cfg=cfg(intrinsics_enabled)");
+
+    // Disabled by default; `unstable-intrinsics` enables again; `force-soft-floats` overrides
+    // to disable.
+    if cfg!(feature = "unstable-intrinsics") && !cfg!(feature = "force-soft-floats") {
+        println!("cargo:rustc-cfg=intrinsics_enabled");
+    }
+}
+
+/// Simplify the feature logic for enabling arch-specific features so code only needs to use
+/// `cfg(arch_enabled)`.
+fn emit_arch_cfg() {
+    println!("cargo:rustc-check-cfg=cfg(arch_enabled)");
+
+    // Enabled by default via the "arch" feature, `force-soft-floats` overrides to disable.
+    if cfg!(feature = "arch") && !cfg!(feature = "force-soft-floats") {
+        println!("cargo:rustc-cfg=arch_enabled");
+    }
+}
+
+/// Some tests are extremely slow. Emit a config option based on optimization level.
+fn emit_optimization_cfg(cfg: &Config) {
+    println!("cargo:rustc-check-cfg=cfg(optimizations_enabled)");
+
+    if cfg.opt_level >= 2 {
+        println!("cargo:rustc-cfg=optimizations_enabled");
+    }
+}
+
+/// Provide an alias for common longer config combinations.
+fn emit_cfg_shorthands(cfg: &Config) {
+    println!("cargo:rustc-check-cfg=cfg(x86_no_sse)");
+    if cfg.target_arch == "x86" && !cfg.target_features.iter().any(|f| f == "sse") {
+        // Shorthand to detect i586 targets
+        println!("cargo:rustc-cfg=x86_no_sse");
+    }
+}
+
+/// Configure whether or not `f16` and `f128` support should be enabled.
+fn emit_f16_f128_cfg(cfg: &Config) {
+    println!("cargo:rustc-check-cfg=cfg(f16_enabled)");
+    println!("cargo:rustc-check-cfg=cfg(f128_enabled)");
+
+    // `unstable-float` enables these features.
+    if !cfg!(feature = "unstable-float") {
+        return;
+    }
+
+    // Set whether or not `f16` and `f128` are supported at a basic level by LLVM. This only means
+    // that the backend will not crash when using these types and generates code that can be called
+    // without crashing (no infinite recursion). This does not mean that the platform doesn't have
+    // ABI or other bugs.
+    //
+    // We do this here rather than in `rust-lang/rust` because configuring via cargo features is
+    // not straightforward.
+    //
+    // Original source of this list:
+    // <https://github.com/rust-lang/compiler-builtins/pull/652#issuecomment-2266151350>
+    let f16_enabled = match cfg.target_arch.as_str() {
+        // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
+        "arm64ec" => false,
+        // Selection failure <https://github.com/llvm/llvm-project/issues/50374>
+        "s390x" => false,
+        // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>
+        // FIXME(llvm): loongarch fixed by <https://github.com/llvm/llvm-project/pull/107791>
+        "csky" => false,
+        "hexagon" => false,
+        "loongarch64" => false,
+        "mips" | "mips64" | "mips32r6" | "mips64r6" => false,
+        "powerpc" | "powerpc64" => false,
+        "sparc" | "sparc64" => false,
+        "wasm32" | "wasm64" => false,
+        // Most everything else works as of LLVM 19
+        _ => true,
+    };
+
+    let f128_enabled = match cfg.target_arch.as_str() {
+        // Unsupported (libcall is not supported) <https://github.com/llvm/llvm-project/issues/121122>
+        "amdgpu" => false,
+        // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
+        "arm64ec" => false,
+        // Selection failure <https://github.com/llvm/llvm-project/issues/96432>
+        "mips64" | "mips64r6" => false,
+        // Selection failure <https://github.com/llvm/llvm-project/issues/95471>
+        "nvptx64" => false,
+        // Selection failure <https://github.com/llvm/llvm-project/issues/101545>
+        "powerpc64" if &cfg.target_os == "aix" => false,
+        // Selection failure <https://github.com/llvm/llvm-project/issues/41838>
+        "sparc" => false,
+        // Most everything else works as of LLVM 19
+        _ => true,
+    };
+
+    // If the feature is set, disable these types.
+    let disable_both = env::var_os("CARGO_FEATURE_NO_F16_F128").is_some();
+
+    println!("cargo:rustc-check-cfg=cfg(f16_enabled)");
+    println!("cargo:rustc-check-cfg=cfg(f128_enabled)");
+
+    if f16_enabled && !disable_both {
+        println!("cargo:rustc-cfg=f16_enabled");
+    }
+
+    if f128_enabled && !disable_both {
+        println!("cargo:rustc-cfg=f128_enabled");
+    }
+}

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -21,5 +21,7 @@ force-soft-floats = []
 unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(arch_enabled)",
   "cfg(assert_no_panic)",
+  "cfg(f128_enabled)",
+  "cfg(f16_enabled)",
   "cfg(intrinsics_enabled)",
 ] }

--- a/crates/libm-macros/Cargo.toml
+++ b/crates/libm-macros/Cargo.toml
@@ -12,3 +12,10 @@ heck = "0.5.0"
 proc-macro2 = "1.0.88"
 quote = "1.0.37"
 syn = { version = "2.0.79", features = ["full", "extra-traits", "visit-mut"] }
+
+[lints.rust]
+# Values used during testing
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(f16_enabled)',
+  'cfg(f128_enabled)',
+] }

--- a/crates/libm-macros/src/lib.rs
+++ b/crates/libm-macros/src/lib.rs
@@ -13,6 +13,13 @@ use syn::{Ident, ItemEnum};
 
 const ALL_FUNCTIONS: &[(Ty, Signature, Option<Signature>, &[&str])] = &[
     (
+        // `fn(f16) -> f16`
+        Ty::F16,
+        Signature { args: &[Ty::F16], returns: &[Ty::F16] },
+        None,
+        &["fabsf16"],
+    ),
+    (
         // `fn(f32) -> f32`
         Ty::F32,
         Signature { args: &[Ty::F32], returns: &[Ty::F32] },
@@ -35,6 +42,20 @@ const ALL_FUNCTIONS: &[(Ty, Signature, Option<Signature>, &[&str])] = &[
             "log1p", "log2", "log", "rint", "round", "sin", "sinh", "sqrt", "tan", "tanh",
             "tgamma", "trunc",
         ],
+    ),
+    (
+        // `fn(f128) -> f128`
+        Ty::F128,
+        Signature { args: &[Ty::F128], returns: &[Ty::F128] },
+        None,
+        &["fabsf128"],
+    ),
+    (
+        // `(f16, f16) -> f16`
+        Ty::F16,
+        Signature { args: &[Ty::F16, Ty::F16], returns: &[Ty::F16] },
+        None,
+        &["copysignf16"],
     ),
     (
         // `(f32, f32) -> f32`
@@ -71,6 +92,13 @@ const ALL_FUNCTIONS: &[(Ty, Signature, Option<Signature>, &[&str])] = &[
             "pow",
             "remainder",
         ],
+    ),
+    (
+        // `(f128, f128) -> f128`
+        Ty::F128,
+        Signature { args: &[Ty::F128, Ty::F128], returns: &[Ty::F128] },
+        None,
+        &["copysignf128"],
     ),
     (
         // `(f32, f32, f32) -> f32`

--- a/crates/libm-macros/src/lib.rs
+++ b/crates/libm-macros/src/lib.rs
@@ -218,7 +218,7 @@ const KNOWN_TYPES: &[&str] = &["FTy", "CFn", "CArgs", "CRet", "RustFn", "RustArg
 
 /// A type used in a function signature.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Ty {
     F16,
     F32,
@@ -359,7 +359,7 @@ pub fn base_name_enum(attributes: pm::TokenStream, tokens: pm::TokenStream) -> p
 ///         // The Rust version's return type (e.g. `(f32, f32)`)
 ///         RustRet: $RustRet:ty,
 ///         // Attributes for the current function, if any
-///         attrs: [$($meta:meta)*]
+///         attrs: [$($meta:meta),*],
 ///         // Extra tokens passed directly (if any)
 ///         extra: [$extra:ident],
 ///         // Extra function-tokens passed directly (if any)
@@ -377,6 +377,8 @@ pub fn base_name_enum(attributes: pm::TokenStream, tokens: pm::TokenStream) -> p
 ///     skip: [sin, cos],
 ///     // Attributes passed as `attrs` for specific functions. For example, here the invocation
 ///     // with `sinf` and that with `cosf` will both get `meta1` and `meta2`, but no others will.
+///     // Note that `f16_enabled` and `f128_enabled` will always get emitted regardless of whether
+///     // or not this is specified.
 ///     attributes: [
 ///         #[meta1]
 ///         #[meta2]
@@ -535,16 +537,28 @@ fn expand(input: StructuredInput, fn_list: &[&FunctionInfo]) -> syn::Result<pm2:
         let fn_name = Ident::new(func.name, Span::call_site());
 
         // Prepare attributes in an `attrs: ...` field
-        let meta_field = match &input.attributes {
-            Some(attrs) => {
-                let meta = attrs
-                    .iter()
-                    .filter(|map| map.names.contains(&fn_name))
-                    .flat_map(|map| &map.meta);
-                quote! { attrs: [ #( #meta )* ]  }
-            }
-            None => pm2::TokenStream::new(),
-        };
+        let mut meta_fields = Vec::new();
+        if let Some(attrs) = &input.attributes {
+            let meta_iter = attrs
+                .iter()
+                .filter(|map| map.names.contains(&fn_name))
+                .flat_map(|map| &map.meta)
+                .map(|v| v.into_token_stream());
+
+            meta_fields.extend(meta_iter);
+        }
+
+        // Always emit f16 and f128 meta so this doesn't need to be repeated everywhere
+        if func.rust_sig.args.contains(&Ty::F16) || func.rust_sig.returns.contains(&Ty::F16) {
+            let ts = quote! { cfg(f16_enabled) };
+            meta_fields.push(ts);
+        }
+        if func.rust_sig.args.contains(&Ty::F128) || func.rust_sig.returns.contains(&Ty::F128) {
+            let ts = quote! { cfg(f128_enabled) };
+            meta_fields.push(ts);
+        }
+
+        let meta_field = quote! { attrs: [ #( #meta_fields ),* ], };
 
         // Prepare extra in an `extra: ...` field, running the replacer
         let extra_field = match input.extra.clone() {

--- a/crates/libm-macros/tests/basic.rs
+++ b/crates/libm-macros/tests/basic.rs
@@ -1,4 +1,6 @@
 // `STATUS_DLL_NOT_FOUND` on i686 MinGW, not worth looking into.
+#![feature(f16)]
+#![feature(f128)]
 #![cfg(not(all(target_arch = "x86", target_os = "windows", target_env = "gnu")))]
 
 macro_rules! basic {
@@ -11,7 +13,7 @@ macro_rules! basic {
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
         RustRet: $RustRet:ty,
-        attrs: [$($meta:meta)*]
+        attrs: [$($meta:meta),*],
         extra: [$($extra_tt:tt)*],
         fn_extra: $fn_extra:expr,
     ) => {
@@ -60,6 +62,7 @@ mod test_basic {
 macro_rules! basic_no_extra {
     (
         fn_name: $fn_name:ident,
+        attrs: [$($meta:meta),*],
     ) => {
         mod $fn_name {}
     };
@@ -85,6 +88,7 @@ macro_rules! specified_types {
         fn_name: $fn_name:ident,
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
+        attrs: [$($meta:meta),*],
     ) => {
         mod $fn_name {
             #[allow(unused)]

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 default = ["unstable-float"]
 
 # Propagated from libm because this affects which functions we test.
-unstable-float = ["libm/unstable-float"]
+unstable-float = ["libm/unstable-float", "rug?/nightly-float"]
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
@@ -51,5 +51,5 @@ harness = false
 [lints.rust]
 # Values from the chared config.rs used by `libm` but not the test crate
 unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(feature, values("arch", "force-soft-floats", "no-f16-f128", "unstable-intrinsics"))',
+  'cfg(feature, values("arch", "force-soft-floats", "unstable-intrinsics"))',
 ] }

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2021"
 publish = false
 
 [features]
-default = []
+default = ["unstable-float"]
+
+# Propagated from libm because this affects which functions we test.
+unstable-float = ["libm/unstable-float"]
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
@@ -44,3 +47,9 @@ criterion = { version = "0.5.1", default-features = false, features = ["cargo_be
 [[bench]]
 name = "random"
 harness = false
+
+[lints.rust]
+# Values from the chared config.rs used by `libm` but not the test crate
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(feature, values("arch", "force-soft-floats", "no-f16-f128", "unstable-intrinsics"))',
+] }

--- a/crates/libm-test/benches/random.rs
+++ b/crates/libm-test/benches/random.rs
@@ -18,7 +18,8 @@ struct MuslExtra<F> {
 macro_rules! musl_rand_benches {
     (
         fn_name: $fn_name:ident,
-        fn_extra: $skip_on_i586:expr,
+        attrs: [$($meta:meta)*],
+        fn_extra: ($skip_on_i586:expr, $musl_fn:expr),
     ) => {
         paste::paste! {
             fn [< musl_bench_ $fn_name >](c: &mut Criterion) {
@@ -26,7 +27,7 @@ macro_rules! musl_rand_benches {
 
                 #[cfg(feature = "build-musl")]
                 let musl_extra = MuslExtra {
-                    musl_fn: Some(musl_math_sys::$fn_name as libm_test::OpCFn<Op>),
+                    musl_fn: $musl_fn,
                     skip_on_i586: $skip_on_i586
                 };
 
@@ -64,7 +65,10 @@ where
             break;
         }
 
-        let musl_res = input.call(musl_extra.musl_fn.unwrap());
+        let Some(musl_fn) = musl_extra.musl_fn else {
+            continue;
+        };
+        let musl_res = input.call(musl_fn);
         let crate_res = input.call(Op::ROUTINE);
 
         crate_res.validate(musl_res, input, &ctx).context(name).unwrap();
@@ -88,15 +92,16 @@ where
     // Don't test against musl if it is not available
     #[cfg(feature = "build-musl")]
     {
-        let musl_fn = musl_extra.musl_fn.unwrap();
-        group.bench_function("musl", |b| {
-            b.iter(|| {
-                let f = black_box(musl_fn);
-                for input in benchvec.iter().copied() {
-                    input.call(f);
-                }
-            })
-        });
+        if let Some(musl_fn) = musl_extra.musl_fn {
+            group.bench_function("musl", |b| {
+                b.iter(|| {
+                    let f = black_box(musl_fn);
+                    for input in benchvec.iter().copied() {
+                        input.call(f);
+                    }
+                })
+            });
+        }
     }
 }
 
@@ -104,15 +109,22 @@ libm_macros::for_each_function! {
     callback: musl_rand_benches,
     skip: [],
     fn_extra: match MACRO_FN_NAME {
-        // FIXME(correctness): wrong result on i586
-        exp10 | exp10f | exp2 | exp2f => true,
-        _ => false
+        // We pass a tuple of `(skip_on_i586, musl_fn)`. By default we never skip (false) and
+        // we do pass a function, but there are a couple exceptions.
+        // FIXME(correctness): exp functions have the wrong result on i586
+        exp10 | exp10f | exp2 | exp2f => (
+            true, Some(musl_math_sys::MACRO_FN_NAME as <Op as MathOp>::CFn)
+        ),
+        // Musl does not provide `f16` and `f128` functions
+        copysignf16 | copysignf128 | fabsf16 | fabsf128 => (false, None),
+        _ => (false, Some(musl_math_sys::MACRO_FN_NAME as <Op as MathOp>::CFn))
     }
 }
 
 macro_rules! run_callback {
     (
         fn_name: $fn_name:ident,
+        attrs: [$($meta:meta)*],
         extra: [$criterion:ident],
     ) => {
         paste::paste! {

--- a/crates/libm-test/build.rs
+++ b/crates/libm-test/build.rs
@@ -1,66 +1,16 @@
 use std::fmt::Write;
-use std::path::PathBuf;
-use std::{env, fs};
+use std::fs;
+
+#[path = "../../configure.rs"]
+mod configure;
+use configure::Config;
 
 fn main() {
     let cfg = Config::from_env();
 
-    emit_optimization_cfg(&cfg);
-    emit_cfg_shorthands(&cfg);
     list_all_tests(&cfg);
-}
 
-#[allow(dead_code)]
-struct Config {
-    manifest_dir: PathBuf,
-    out_dir: PathBuf,
-    opt_level: u8,
-    target_arch: String,
-    target_env: String,
-    target_family: Option<String>,
-    target_os: String,
-    target_string: String,
-    target_vendor: String,
-    target_features: Vec<String>,
-}
-
-impl Config {
-    fn from_env() -> Self {
-        let target_features = env::var("CARGO_CFG_TARGET_FEATURE")
-            .map(|feats| feats.split(',').map(ToOwned::to_owned).collect())
-            .unwrap_or_default();
-
-        Self {
-            manifest_dir: PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()),
-            out_dir: PathBuf::from(env::var("OUT_DIR").unwrap()),
-            opt_level: env::var("OPT_LEVEL").unwrap().parse().unwrap(),
-            target_arch: env::var("CARGO_CFG_TARGET_ARCH").unwrap(),
-            target_env: env::var("CARGO_CFG_TARGET_ENV").unwrap(),
-            target_family: env::var("CARGO_CFG_TARGET_FAMILY").ok(),
-            target_os: env::var("CARGO_CFG_TARGET_OS").unwrap(),
-            target_string: env::var("TARGET").unwrap(),
-            target_vendor: env::var("CARGO_CFG_TARGET_VENDOR").unwrap(),
-            target_features,
-        }
-    }
-}
-
-/// Some tests are extremely slow. Emit a config option based on optimization level.
-fn emit_optimization_cfg(cfg: &Config) {
-    println!("cargo::rustc-check-cfg=cfg(optimizations_enabled)");
-
-    if cfg.opt_level >= 2 {
-        println!("cargo::rustc-cfg=optimizations_enabled");
-    }
-}
-
-/// Provide an alias for common longer config combinations.
-fn emit_cfg_shorthands(cfg: &Config) {
-    println!("cargo::rustc-check-cfg=cfg(x86_no_sse)");
-    if cfg.target_arch == "x86" && !cfg.target_features.iter().any(|f| f == "sse") {
-        // Shorthand to detect i586 targets
-        println!("cargo::rustc-cfg=x86_no_sse");
-    }
+    configure::emit_test_config(&cfg);
 }
 
 /// Create a list of all source files in an array. This can be used for making sure that

--- a/crates/libm-test/src/gen.rs
+++ b/crates/libm-test/src/gen.rs
@@ -6,9 +6,27 @@ pub mod random;
 /// Helper type to turn any reusable input into a generator.
 #[derive(Clone, Debug, Default)]
 pub struct CachedInput {
+    #[cfg(f16_enabled)]
+    pub inputs_f16: Vec<(f16, f16, f16)>,
     pub inputs_f32: Vec<(f32, f32, f32)>,
     pub inputs_f64: Vec<(f64, f64, f64)>,
+    #[cfg(f128_enabled)]
+    pub inputs_f128: Vec<(f128, f128, f128)>,
     pub inputs_i32: Vec<(i32, i32, i32)>,
+}
+
+#[cfg(f16_enabled)]
+impl GenerateInput<(f16,)> for CachedInput {
+    fn get_cases(&self) -> impl Iterator<Item = (f16,)> {
+        self.inputs_f16.iter().map(|f| (f.0,))
+    }
+}
+
+#[cfg(f16_enabled)]
+impl GenerateInput<(f16, f16)> for CachedInput {
+    fn get_cases(&self) -> impl Iterator<Item = (f16, f16)> {
+        self.inputs_f16.iter().map(|f| (f.0, f.1))
+    }
 }
 
 impl GenerateInput<(f32,)> for CachedInput {
@@ -68,5 +86,19 @@ impl GenerateInput<(f64, i32)> for CachedInput {
 impl GenerateInput<(f64, f64, f64)> for CachedInput {
     fn get_cases(&self) -> impl Iterator<Item = (f64, f64, f64)> {
         self.inputs_f64.iter().copied()
+    }
+}
+
+#[cfg(f128_enabled)]
+impl GenerateInput<(f128,)> for CachedInput {
+    fn get_cases(&self) -> impl Iterator<Item = (f128,)> {
+        self.inputs_f128.iter().map(|f| (f.0,))
+    }
+}
+
+#[cfg(f128_enabled)]
+impl GenerateInput<(f128, f128)> for CachedInput {
+    fn get_cases(&self) -> impl Iterator<Item = (f128, f128)> {
+        self.inputs_f128.iter().map(|f| (f.0, f.1))
     }
 }

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(f128_enabled, feature(f128))]
+#![cfg_attr(f16_enabled, feature(f16))]
+
 pub mod gen;
 #[cfg(feature = "test-multiprecision")]
 pub mod mpfloat;

--- a/crates/libm-test/src/op.rs
+++ b/crates/libm-test/src/op.rs
@@ -92,8 +92,10 @@ macro_rules! do_thing {
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
         RustRet: $RustRet:ty,
+        attrs: [$($meta:meta),*],
     ) => {
         paste::paste! {
+            $(#[$meta])*
             pub mod $fn_name {
                 use super::*;
                 pub struct Routine;

--- a/crates/libm-test/src/test_traits.rs
+++ b/crates/libm-test/src/test_traits.rs
@@ -346,6 +346,12 @@ where
 
 impl_float!(f32, f64);
 
+#[cfg(f16_enabled)]
+impl_float!(f16);
+
+#[cfg(f128_enabled)]
+impl_float!(f128);
+
 /* trait implementations for compound types */
 
 /// Implement `CheckOutput` for combinations of types.

--- a/crates/libm-test/tests/check_coverage.rs
+++ b/crates/libm-test/tests/check_coverage.rs
@@ -22,6 +22,7 @@ const ALLOWED_SKIPS: &[&str] = &[
 macro_rules! callback {
     (
         fn_name: $name:ident,
+        attrs: [$($_meta:meta),*],
         extra: [$push_to:ident],
     ) => {
         $push_to.push(stringify!($name));

--- a/crates/libm-test/tests/compare_built_musl.rs
+++ b/crates/libm-test/tests/compare_built_musl.rs
@@ -15,7 +15,7 @@ use libm_test::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleC
 macro_rules! musl_rand_tests {
     (
         fn_name: $fn_name:ident,
-        attrs: [$($meta:meta)*]
+        attrs: [$($meta:meta),*],
     ) => {
         paste::paste! {
             #[test]
@@ -45,6 +45,8 @@ where
 
 libm_macros::for_each_function! {
     callback: musl_rand_tests,
+    // Musl has no implementations for `f16` and `f128` (on all platforms)
+    skip: [copysignf16, copysignf128, fabsf16, fabsf128],
     attributes: [
         #[cfg_attr(x86_no_sse, ignore)] // FIXME(correctness): wrong result on i586
         [exp10, exp10f, exp2, exp2f, rint]

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -1,6 +1,8 @@
 //! Test with "infinite precision"
 
 #![cfg(feature = "test-multiprecision")]
+#![cfg_attr(f128_enabled, feature(f128))]
+#![cfg_attr(f16_enabled, feature(f16))]
 
 use libm_test::gen::{CachedInput, random};
 use libm_test::mpfloat::MpOp;
@@ -10,11 +12,16 @@ use libm_test::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleC
 macro_rules! mp_rand_tests {
     (
         fn_name: $fn_name:ident,
-        attrs: [$($meta:meta)*]
+        attrs: [$($meta:meta),*],
     ) => {
         paste::paste! {
             #[test]
             $(#[$meta])*
+            // #[cfg_attr(all(
+            //     optimizations_enabled,
+            //     any(target_arch = "powerpc", target_arch = "powerpc64")),
+            //     ignore = "stack overflow on PowerPC without optimizations"
+            // )]
             fn [< mp_random_ $fn_name >]() {
                 test_one::<libm_test::op::$fn_name::Routine>();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![no_std]
 #![cfg_attr(intrinsics_enabled, allow(internal_features))]
 #![cfg_attr(intrinsics_enabled, feature(core_intrinsics))]
+#![cfg_attr(f128_enabled, feature(f128))]
+#![cfg_attr(f16_enabled, feature(f16))]
 #![allow(clippy::assign_op_pattern)]
 #![allow(clippy::deprecated_cfg_attr)]
 #![allow(clippy::eq_op)]

--- a/src/libm_helper.rs
+++ b/src/libm_helper.rs
@@ -30,7 +30,7 @@ macro_rules! libm_helper {
         }
     };
 
-    ({$($func:tt);*}) => {
+    ({$($func:tt;)*}) => {
         $(
             libm_helper! { $func }
         )*
@@ -103,7 +103,7 @@ libm_helper! {
         (fn trunc(x: f32) -> (f32);                 => truncf);
         (fn y0(x: f32) -> (f32);                    => y0f);
         (fn y1(x: f32) -> (f32);                    => y1f);
-        (fn yn(n: i32, x: f32) -> (f32);            => ynf)
+        (fn yn(n: i32, x: f32) -> (f32);            => ynf);
     }
 }
 
@@ -166,6 +166,24 @@ libm_helper! {
         (fn trunc(x: f64) -> (f64);                 => trunc);
         (fn y0(x: f64) -> (f64);                    => y0);
         (fn y1(x: f64) -> (f64);                    => y1);
-        (fn yn(n: i32, x: f64) -> (f64);            => yn)
+        (fn yn(n: i32, x: f64) -> (f64);            => yn);
+    }
+}
+
+#[cfg(f16_enabled)]
+libm_helper! {
+    f16,
+    funcs: {
+        (fn abs(x: f16) -> (f16);                   => fabsf16);
+        (fn copysign(x: f16, y: f16) -> (f16);      => copysignf16);
+    }
+}
+
+#[cfg(f128_enabled)]
+libm_helper! {
+    f128,
+    funcs: {
+        (fn abs(x: f128) -> (f128);                 => fabsf128);
+        (fn copysign(x: f128, y: f128) -> (f128);   => copysignf128);
     }
 }

--- a/src/math/copysign.rs
+++ b/src/math/copysign.rs
@@ -4,9 +4,5 @@
 /// first argument, `x`, and the sign of its second argument, `y`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn copysign(x: f64, y: f64) -> f64 {
-    let mut ux = x.to_bits();
-    let uy = y.to_bits();
-    ux &= (!0) >> 1;
-    ux |= uy & (1 << 63);
-    f64::from_bits(ux)
+    super::generic::copysign::copysign(x, y)
 }

--- a/src/math/copysignf.rs
+++ b/src/math/copysignf.rs
@@ -4,9 +4,5 @@
 /// first argument, `x`, and the sign of its second argument, `y`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn copysignf(x: f32, y: f32) -> f32 {
-    let mut ux = x.to_bits();
-    let uy = y.to_bits();
-    ux &= 0x7fffffff;
-    ux |= uy & 0x80000000;
-    f32::from_bits(ux)
+    super::generic::copysign::copysign(x, y)
 }

--- a/src/math/copysignf128.rs
+++ b/src/math/copysignf128.rs
@@ -1,0 +1,8 @@
+/// Sign of Y, magnitude of X (f32)
+///
+/// Constructs a number with the magnitude (absolute value) of its
+/// first argument, `x`, and the sign of its second argument, `y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn copysignf128(x: f128, y: f128) -> f128 {
+    super::generic::copysign::copysign(x, y)
+}

--- a/src/math/copysignf16.rs
+++ b/src/math/copysignf16.rs
@@ -1,0 +1,8 @@
+/// Sign of Y, magnitude of X (f32)
+///
+/// Constructs a number with the magnitude (absolute value) of its
+/// first argument, `x`, and the sign of its second argument, `y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn copysignf16(x: f16, y: f16) -> f16 {
+    super::generic::copysign::copysign(x, y)
+}

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -9,7 +9,7 @@ pub fn fabs(x: f64) -> f64 {
         args: x,
     }
 
-    f64::from_bits(x.to_bits() & (u64::MAX / 2))
+    super::generic::abs::abs(x)
 }
 
 #[cfg(test)]

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -9,7 +9,7 @@ pub fn fabsf(x: f32) -> f32 {
         args: x,
     }
 
-    f32::from_bits(x.to_bits() & 0x7fffffff)
+    super::generic::abs::abs(x)
 }
 
 // PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520

--- a/src/math/fabsf128.rs
+++ b/src/math/fabsf128.rs
@@ -1,0 +1,5 @@
+/// Absolute value (magnitude) of a `f128` value.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn fabsf128(x: f128) -> f128 {
+    super::generic::abs::abs(x)
+}

--- a/src/math/fabsf16.rs
+++ b/src/math/fabsf16.rs
@@ -1,0 +1,5 @@
+/// Absolute value (magnitude) of a `f16` value.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn fabsf16(x: f16) -> f16 {
+    super::generic::abs::abs(x)
+}

--- a/src/math/generic/abs.rs
+++ b/src/math/generic/abs.rs
@@ -1,0 +1,5 @@
+use super::super::Float;
+
+pub fn abs<F: Float>(x: F) -> F {
+    x.abs()
+}

--- a/src/math/generic/copysign.rs
+++ b/src/math/generic/copysign.rs
@@ -1,0 +1,9 @@
+use super::super::Float;
+
+pub fn copysign<F: Float>(x: F, y: F) -> F {
+    let mut ux = x.to_bits();
+    let uy = y.to_bits();
+    ux &= !F::SIGN_MASK;
+    ux |= uy & (F::SIGN_MASK);
+    F::from_bits(ux)
+}

--- a/src/math/generic/mod.rs
+++ b/src/math/generic/mod.rs
@@ -1,0 +1,2 @@
+pub mod abs;
+pub mod copysign;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -87,6 +87,7 @@ mod support;
 mod arch;
 mod expo2;
 mod fenv;
+mod generic;
 mod k_cos;
 mod k_cosf;
 mod k_expo2;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -332,6 +332,26 @@ pub use self::tgammaf::tgammaf;
 pub use self::trunc::trunc;
 pub use self::truncf::truncf;
 
+cfg_if! {
+    if #[cfg(f16_enabled)] {
+        mod copysignf16;
+        mod fabsf16;
+
+        pub use self::fabsf16::fabsf16;
+        pub use self::copysignf16::copysignf16;
+    }
+}
+
+cfg_if! {
+    if #[cfg(f128_enabled)] {
+        mod copysignf128;
+        mod fabsf128;
+
+        pub use self::fabsf128::fabsf128;
+        pub use self::copysignf128::copysignf128;
+    }
+}
+
 #[inline]
 fn get_high_word(x: f64) -> u32 {
     (x.to_bits() >> 32) as u32

--- a/src/math/support/float_traits.rs
+++ b/src/math/support/float_traits.rs
@@ -219,5 +219,9 @@ macro_rules! float_impl {
     };
 }
 
+#[cfg(f16_enabled)]
+float_impl!(f16, u16, i16, i8, 16, 10);
 float_impl!(f32, u32, i32, i16, 32, 23);
 float_impl!(f64, u64, i64, i16, 64, 52);
+#[cfg(f128_enabled)]
+float_impl!(f128, u128, i128, i16, 128, 112);


### PR DESCRIPTION
Add generic versions of `abs` and `copysign`, which is used to implement `f16` and `f128` versions of these functions. These currently aren't tested because the builtin `musl` tests don't provide a reference, but the implementations are straightforward and we will be able to test against https://github.com/rust-lang/libm/pull/311 once it lands. (Technically musl on aarch64 has `fabsl` and `copysignl` as `f128`, but I don't think it is worth updating the serialization tests).

The second commit ("Add float and integer traits...") just copies the exact trait implementations that we use in `compiler-builtins`, with the assumption that we will use it more in the future and for testing.

The third commit ("Add f16 and f128 configuration...") copies the logic from `compiler-builtins` for setting `enable_f16` and `enable_f128` with the exception that here, the `unstable` feature must also be enabled. This will probably need to be tweaked a bit in the future so it isn't tied to other behavior enabled by `unstable`, but this is enough to get us started.