### PR TITLE
Add a CI test that the crate builds on stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,16 @@ jobs:
     - run: cargo generate-lockfile
     - run: ./ci/run-docker.sh ${{ matrix.target }}
 
+  stable:
+    name: Build succeeds on stable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - run: cargo build -p libm
+
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently everything we have runs with nightly Rust. Add a stable test to make sure we don't accidentally make use of behavior that isn't yet stable without gating it.