### PR TITLE
Don't deny warnings when checking MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,8 @@ jobs:
   msrv:
     name: Check MSRV
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: # No need to check warnings on old MSRV, unset `-Dwarnings`
     steps:
     - uses: actions/checkout@master
     - run: |


### PR DESCRIPTION
1.63 reports some false positive lints that we don't need to worry about. Make sure we don't fail CI for this.