### PR TITLE
Reduce the number of iterations on emulated aarch64 Linux

### DIFF
--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,10 +5,20 @@
 
 set -euxo pipefail
 
+host_arch="$(uname -m | sed 's/arm64/aarch64/')"
+
 run() {
     local target=$1
 
     echo "testing target: $target"
+
+    target_arch="$(echo "$target" | cut -d'-' -f1)"
+
+    emulated=""
+    if [ "$target_arch" != "$host_arch" ]; then
+        emulated=1
+        echo "target is emulated"
+    fi
 
     # This directory needs to exist before calling docker, otherwise docker will create it but it
     # will be owned by root
@@ -16,28 +26,28 @@ run() {
 
     docker build -t "$target" "ci/docker/$target"
     docker run \
-           --rm \
-           --user "$(id -u):$(id -g)" \
-           -e RUSTFLAGS \
-           -e CARGO_HOME=/cargo \
-           -e CARGO_TARGET_DIR=/target \
-           -e EMULATED=1 \
-           -v "${HOME}/.cargo:/cargo" \
-           -v "$(pwd)/target:/target" \
-           -v "$(pwd):/checkout:ro" \
-           -v "$(rustc --print sysroot):/rust:ro" \
-           --init \
-           -w /checkout \
-           "$target" \
-           sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh $target"
+        --rm \
+        --user "$(id -u):$(id -g)" \
+        -e RUSTFLAGS \
+        -e CARGO_HOME=/cargo \
+        -e CARGO_TARGET_DIR=/target \
+        -e "EMULATED=$emulated" \
+        -v "${HOME}/.cargo:/cargo" \
+        -v "$(pwd)/target:/target" \
+        -v "$(pwd):/checkout:ro" \
+        -v "$(rustc --print sysroot):/rust:ro" \
+        --init \
+        -w /checkout \
+        "$target" \
+        sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh $target"
 }
 
 if [ -z "$1" ]; then
-  echo "running tests for all targets"
+    echo "running tests for all targets"
 
-  for d in ci/docker/*; do
-    run $d
-  done
+    for d in ci/docker/*; do
+        run $d
+    done
 else
-  run $1
+    run $1
 fi

--- a/crates/libm-test/src/gen/random.rs
+++ b/crates/libm-test/src/gen/random.rs
@@ -13,31 +13,21 @@ const SEED: [u8; 32] = *b"3.141592653589793238462643383279";
 
 /// Number of tests to run.
 const NTESTS: usize = {
-    let ntests = if cfg!(optimizations_enabled) {
-        if cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64") {
-            5_000_000
-        } else if !cfg!(target_pointer_width = "64")
+    if cfg!(optimizations_enabled) {
+        if crate::emulated()
+            || !cfg!(target_pointer_width = "64")
             || cfg!(all(target_arch = "x86_64", target_vendor = "apple"))
-            || option_env!("EMULATED").is_some()
-                && cfg!(any(target_arch = "aarch64", target_arch = "powerpc64"))
         {
-            // Tests are pretty slow on:
-            // - Non-64-bit targets
-            // - Emulated ppc
-            // - Emulated aarch64
-            // - x86 MacOS
-            // So reduce the number of iterations
+            // Tests are pretty slow on non-64-bit targets, x86 MacOS, and targets that run
+            // in QEMU.
             100_000
         } else {
-            // Most everything else gets tested in docker and works okay, but we still
-            // don't need 20 minutes of tests.
-            1_000_000
+            5_000_000
         }
     } else {
+        // Without optimizations just run a quick check
         800
-    };
-
-    ntests
+    }
 };
 
 /// Tested inputs.

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -62,3 +62,12 @@ pub fn canonical_name(name: &str) -> &str {
             .unwrap_or(name),
     }
 }
+
+/// True if `EMULATED` is set and nonempty. Used to determine how many iterations to run.
+pub const fn emulated() -> bool {
+    match option_env!("EMULATED") {
+        Some(s) if s.is_empty() => false,
+        None => false,
+        Some(_) => true,
+    }
+}


### PR DESCRIPTION
CI for aarch64 Linux is significantly slower than the others. Adjust how iteration selection is done to better handle this case, which also simplifies things.

Also set the `EMULATED` environment variable in Docker to be more accurate, and reindents run-docker.sh.