### PR TITLE
Adjust how intrinsics are enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ default = []
 
 # This tells the compiler to assume that a Nightly toolchain is being used and
 # that it should activate any useful Nightly things accordingly.
-unstable = []
+unstable = ["unstable-intrinsics"]
+
+# Enable calls to functions in `core::intrinsics`
+unstable-intrinsics = []
 
 # Used to prevent using any intrinsics or arch-specific code.
 force-soft-floats = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ unstable = ["unstable-intrinsics"]
 unstable-intrinsics = []
 
 # Used to prevent using any intrinsics or arch-specific code.
+#
+# HACK: this is a negative feature which is generally a bad idea in Cargo, but
+# we need it to be able to forbid other features when this crate is used in
+# Rust dependencies. Setting this overrides all features that may enable
+# hard float operations.
 force-soft-floats = []
 
 [workspace]

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rustc-check-cfg=cfg(assert_no_panic)");
-    println!("cargo:rustc-check-cfg=cfg(feature, values(\"unstable\"))");
 
     println!("cargo:rustc-check-cfg=cfg(feature, values(\"checked\"))");
 
@@ -13,5 +12,19 @@ fn main() {
         if lvl != "0" {
             println!("cargo:rustc-cfg=assert_no_panic");
         }
+    }
+
+    configure_intrinsics();
+}
+
+/// Simplify the feature logic for enabling intrinsics so code only needs to use
+/// `cfg(intrinsics_enabled)`.
+fn configure_intrinsics() {
+    println!("cargo:rustc-check-cfg=cfg(intrinsics_enabled)");
+
+    // Disabled by default; `unstable-intrinsics` enables again; `force-soft-floats` overrides
+    // to disable.
+    if cfg!(feature = "unstable-intrinsics") && !cfg!(feature = "force-soft-floats") {
+        println!("cargo:rustc-cfg=intrinsics_enabled");
     }
 }

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -46,6 +46,10 @@ if [ "$(uname -a)" = "Linux" ]; then
     extra_flags="$extra_flags --features libm-test/test-musl-serialized"
 fi
 
+# Make sure we can build with overriding features. We test the indibidual
+# features it controls separately.
+cargo check --features "force-soft-floats"
+
 if [ "${BUILD_ONLY:-}" = "1" ]; then
     cmd="cargo build --target $target --package libm"
     $cmd

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -49,7 +49,7 @@ fi
 if [ "${BUILD_ONLY:-}" = "1" ]; then
     cmd="cargo build --target $target --package libm"
     $cmd
-    $cmd --features 'unstable'
+    $cmd --features "unstable-intrinsics"
 
     echo "can't run tests on $target"
 else
@@ -60,6 +60,6 @@ else
     $cmd --release
 
     # unstable with a feature
-    $cmd --features 'unstable'
-    $cmd --release --features 'unstable'
+    $cmd --features "unstable-intrinsics"
+    $cmd --release --features "unstable-intrinsics"
 fi

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -10,6 +10,8 @@ test = false
 bench = false
 
 [features]
+# Duplicated from libm's Cargo.toml
 unstable = []
+unstable-intrinsics = []
 checked = []
 force-soft-floats = []

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -15,3 +15,9 @@ unstable = []
 unstable-intrinsics = []
 checked = []
 force-soft-floats = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(assert_no_panic)",
+  "cfg(intrinsics_enabled)",
+] }

--- a/crates/compiler-builtins-smoke-test/build.rs
+++ b/crates/compiler-builtins-smoke-test/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("cargo::rustc-check-cfg=cfg(assert_no_panic)");
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! libm in pure Rust
 #![no_std]
-#![cfg_attr(feature = "unstable", allow(internal_features))]
-#![cfg_attr(feature = "unstable", feature(core_intrinsics))]
+#![cfg_attr(feature = "unstable-intrinsics", allow(internal_features))]
+#![cfg_attr(feature = "unstable-intrinsics", feature(core_intrinsics))]
 #![allow(clippy::assign_op_pattern)]
 #![allow(clippy::deprecated_cfg_attr)]
 #![allow(clippy::eq_op)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! libm in pure Rust
 #![no_std]
-#![cfg_attr(feature = "unstable-intrinsics", allow(internal_features))]
-#![cfg_attr(feature = "unstable-intrinsics", feature(core_intrinsics))]
+#![cfg_attr(intrinsics_enabled, allow(internal_features))]
+#![cfg_attr(intrinsics_enabled, feature(core_intrinsics))]
 #![allow(clippy::assign_op_pattern)]
 #![allow(clippy::deprecated_cfg_attr)]
 #![allow(clippy::eq_op)]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -60,14 +60,14 @@ macro_rules! i {
 // the time of this writing this is only used in a few places, and once
 // rust-lang/rust#72751 is fixed then this macro will no longer be necessary and
 // the native `/` operator can be used and panics won't be codegen'd.
-#[cfg(any(debug_assertions, not(feature = "unstable-intrinsics")))]
+#[cfg(any(debug_assertions, not(intrinsics_enabled)))]
 macro_rules! div {
     ($a:expr, $b:expr) => {
         $a / $b
     };
 }
 
-#[cfg(all(not(debug_assertions), feature = "unstable-intrinsics"))]
+#[cfg(all(not(debug_assertions), intrinsics_enabled))]
 macro_rules! div {
     ($a:expr, $b:expr) => {
         unsafe { core::intrinsics::unchecked_div($a, $b) }
@@ -76,9 +76,7 @@ macro_rules! div {
 
 macro_rules! llvm_intrinsically_optimized {
     (#[cfg($($clause:tt)*)] $e:expr) => {
-        #[cfg(all(
-            feature = "unstable-intrinsics", not(feature = "force-soft-floats"), $($clause)*
-        ))]
+        #[cfg(all(intrinsics_enabled, not(feature = "force-soft-floats"), $($clause)*))]
         {
             if true { // thwart the dead code lint
                 $e

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -60,14 +60,14 @@ macro_rules! i {
 // the time of this writing this is only used in a few places, and once
 // rust-lang/rust#72751 is fixed then this macro will no longer be necessary and
 // the native `/` operator can be used and panics won't be codegen'd.
-#[cfg(any(debug_assertions, not(feature = "unstable")))]
+#[cfg(any(debug_assertions, not(feature = "unstable-intrinsics")))]
 macro_rules! div {
     ($a:expr, $b:expr) => {
         $a / $b
     };
 }
 
-#[cfg(all(not(debug_assertions), feature = "unstable"))]
+#[cfg(all(not(debug_assertions), feature = "unstable-intrinsics"))]
 macro_rules! div {
     ($a:expr, $b:expr) => {
         unsafe { core::intrinsics::unchecked_div($a, $b) }
@@ -76,7 +76,9 @@ macro_rules! div {
 
 macro_rules! llvm_intrinsically_optimized {
     (#[cfg($($clause:tt)*)] $e:expr) => {
-        #[cfg(all(feature = "unstable", not(feature = "force-soft-floats"), $($clause)*))]
+        #[cfg(all(
+            feature = "unstable-intrinsics", not(feature = "force-soft-floats"), $($clause)*
+        ))]
         {
             if true { // thwart the dead code lint
                 $e


### PR DESCRIPTION
- Move the existing "unstable" feature to "unstable-intrinsics" ("unstable" still exists, it just enables "unstable-intrinsics")
- Replace `feature = "unstable-intrinsics"` with `intrinsics_enabled`

We currently have a non-additive feature, "force-soft-floats", and we will need to gain another "no-f16-f128". This makes `cfg` usage in code somewhat confusing and redundant.

Use `build.rs` to figure out if "unstable-intrinsics" is enabled while "force-soft-floats" is not enabled and if so, emit a cfg `intrinsics_enabled`. This is cleaner to use and should make adding more features easier to reason about.

Also use this as an opportunity to eliminate the build.rs from the compiler-builtins test crate, replaced with the `[lints]` table in Cargo.toml.