### PR TITLE
Migrate types from a macro to a trait

### DIFF
--- a/crates/libm-macros/Cargo.toml
+++ b/crates/libm-macros/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 proc-macro = true
 
 [dependencies]
+heck = "0.5.0"
 proc-macro2 = "1.0.88"
 quote = "1.0.37"
 syn = { version = "2.0.79", features = ["full", "extra-traits", "visit-mut"] }

--- a/crates/libm-macros/src/enums.rs
+++ b/crates/libm-macros/src/enums.rs
@@ -1,0 +1,132 @@
+use heck::ToUpperCamelCase;
+use proc_macro2 as pm2;
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Fields, ItemEnum, Variant};
+
+use crate::{ALL_FUNCTIONS_FLAT, base_name};
+
+/// Implement `#[function_enum]`, see documentation in `lib.rs`.
+pub fn function_enum(
+    mut item: ItemEnum,
+    attributes: pm2::TokenStream,
+) -> syn::Result<pm2::TokenStream> {
+    expect_empty_enum(&item)?;
+    let attr_span = attributes.span();
+    let mut attr = attributes.into_iter();
+
+    // Attribute should be the identifier of the `BaseName` enum.
+    let Some(tt) = attr.next() else {
+        return Err(syn::Error::new(attr_span, "expected one attribute"));
+    };
+
+    let pm2::TokenTree::Ident(base_enum) = tt else {
+        return Err(syn::Error::new(tt.span(), "expected an identifier"));
+    };
+
+    if let Some(tt) = attr.next() {
+        return Err(syn::Error::new(tt.span(), "unexpected token after identifier"));
+    }
+
+    let enum_name = &item.ident;
+    let mut as_str_arms = Vec::new();
+    let mut base_arms = Vec::new();
+
+    for func in ALL_FUNCTIONS_FLAT.iter() {
+        let fn_name = func.name;
+        let ident = Ident::new(&fn_name.to_upper_camel_case(), Span::call_site());
+        let bname_ident = Ident::new(&base_name(fn_name).to_upper_camel_case(), Span::call_site());
+
+        // Match arm for `fn as_str(self)` matcher
+        as_str_arms.push(quote! { Self::#ident => #fn_name });
+
+        // Match arm for `fn base_name(self)` matcher
+        base_arms.push(quote! { Self::#ident => #base_enum::#bname_ident });
+
+        let variant =
+            Variant { attrs: Vec::new(), ident, fields: Fields::Unit, discriminant: None };
+
+        item.variants.push(variant);
+    }
+
+    let res = quote! {
+        // Instantiate the enum
+        #item
+
+        impl #enum_name {
+            /// The stringified version of this function name.
+            const fn as_str(self) -> &'static str {
+                match self {
+                    #( #as_str_arms , )*
+                }
+            }
+
+            /// The base name enum for this function.
+            const fn base_name(self) -> #base_enum {
+                match self {
+                    #( #base_arms, )*
+                }
+            }
+        }
+    };
+
+    Ok(res)
+}
+
+/// Implement `#[base_name_enum]`, see documentation in `lib.rs`.
+pub fn base_name_enum(
+    mut item: ItemEnum,
+    attributes: pm2::TokenStream,
+) -> syn::Result<pm2::TokenStream> {
+    expect_empty_enum(&item)?;
+    if !attributes.is_empty() {
+        let sp = attributes.span();
+        return Err(syn::Error::new(sp.span(), "no attributes expected"));
+    }
+
+    let mut base_names: Vec<_> =
+        ALL_FUNCTIONS_FLAT.iter().map(|func| base_name(func.name)).collect();
+    base_names.sort_unstable();
+    base_names.dedup();
+
+    let item_name = &item.ident;
+    let mut as_str_arms = Vec::new();
+
+    for base_name in base_names {
+        let ident = Ident::new(&base_name.to_upper_camel_case(), Span::call_site());
+
+        // Match arm for `fn as_str(self)` matcher
+        as_str_arms.push(quote! { Self::#ident => #base_name });
+
+        let variant =
+            Variant { attrs: Vec::new(), ident, fields: Fields::Unit, discriminant: None };
+
+        item.variants.push(variant);
+    }
+
+    let res = quote! {
+        // Instantiate the enum
+        #item
+
+        impl #item_name {
+            /// The stringified version of this base name.
+            const fn as_str(self) -> &'static str {
+                match self {
+                    #( #as_str_arms ),*
+                }
+            }
+        }
+    };
+
+    Ok(res)
+}
+
+/// Verify that an enum is empty, otherwise return an error
+fn expect_empty_enum(item: &ItemEnum) -> syn::Result<()> {
+    if !item.variants.is_empty() {
+        Err(syn::Error::new(item.variants.span(), "expected an empty enum"))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/libm-macros/tests/basic.rs
+++ b/crates/libm-macros/tests/basic.rs
@@ -4,6 +4,7 @@
 macro_rules! basic {
     (
         fn_name: $fn_name:ident,
+        FTy: $FTy:ty,
         CFn: $CFn:ty,
         CArgs: $CArgs:ty,
         CRet: $CRet:ty,
@@ -17,9 +18,9 @@ macro_rules! basic {
         $(#[$meta])*
         mod $fn_name {
             #[allow(unused)]
-            type CFnTy = $CFn;
-            // type CArgsTy<'_> = $CArgs;
-            // type CRetTy<'_> = $CRet;
+            type FTy= $FTy;
+            #[allow(unused)]
+            type CFnTy<'a> = $CFn;
             #[allow(unused)]
             type RustFnTy = $RustFn;
             #[allow(unused)]
@@ -39,6 +40,7 @@ macro_rules! basic {
 mod test_basic {
     libm_macros::for_each_function! {
         callback: basic,
+        emit_types: all,
         skip: [sin, cos],
         attributes: [
             // just some random attributes
@@ -58,25 +60,8 @@ mod test_basic {
 macro_rules! basic_no_extra {
     (
         fn_name: $fn_name:ident,
-        CFn: $CFn:ty,
-        CArgs: $CArgs:ty,
-        CRet: $CRet:ty,
-        RustFn: $RustFn:ty,
-        RustArgs: $RustArgs:ty,
-        RustRet: $RustRet:ty,
     ) => {
-        mod $fn_name {
-            #[allow(unused)]
-            type CFnTy = $CFn;
-            // type CArgsTy<'_> = $CArgs;
-            // type CRetTy<'_> = $CRet;
-            #[allow(unused)]
-            type RustFnTy = $RustFn;
-            #[allow(unused)]
-            type RustArgsTy = $RustArgs;
-            #[allow(unused)]
-            type RustRetTy = $RustRet;
-        }
+        mod $fn_name {}
     };
 }
 
@@ -92,5 +77,28 @@ mod test_only {
     libm_macros::for_each_function! {
         callback: basic_no_extra,
         only: [sin, sinf],
+    }
+}
+
+macro_rules! specified_types {
+    (
+        fn_name: $fn_name:ident,
+        RustFn: $RustFn:ty,
+        RustArgs: $RustArgs:ty,
+    ) => {
+        mod $fn_name {
+            #[allow(unused)]
+            type RustFnTy = $RustFn;
+            #[allow(unused)]
+            type RustArgsTy = $RustArgs;
+        }
+    };
+}
+
+mod test_emit_types {
+    // Test that we can specify a couple types to emit
+    libm_macros::for_each_function! {
+        callback: specified_types,
+        emit_types: [RustFn, RustArgs],
     }
 }

--- a/crates/libm-macros/tests/enum.rs
+++ b/crates/libm-macros/tests/enum.rs
@@ -1,0 +1,19 @@
+#[libm_macros::function_enum(BaseName)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Function {}
+
+#[libm_macros::base_name_enum]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BaseName {}
+
+#[test]
+fn as_str() {
+    assert_eq!(Function::Sin.as_str(), "sin");
+    assert_eq!(Function::Sinf.as_str(), "sinf");
+}
+
+#[test]
+fn basename() {
+    assert_eq!(Function::Sin.base_name(), BaseName::Sin);
+    assert_eq!(Function::Sinf.base_name(), BaseName::Sin);
+}

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod gen;
 #[cfg(feature = "test-multiprecision")]
 pub mod mpfloat;
+pub mod op;
 mod precision;
 mod test_traits;
 
 pub use libm::support::{Float, Int};
+pub use op::{BaseName, MathOp, Name};
 pub use precision::{MaybeOverride, SpecialCase, multiprec_allowed_ulp, musl_allowed_ulp};
 pub use test_traits::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, Hex, TupleCall};
 

--- a/crates/libm-test/src/op.rs
+++ b/crates/libm-test/src/op.rs
@@ -1,0 +1,111 @@
+//! Types representing individual functions.
+//!
+//! Each routine gets a module with its name, e.g. `mod sinf { /* ... */ }`. The module
+//! contains a unit struct `Routine` which implements `MathOp`.
+//!
+//! Basically everything could be called a "function" here, so we loosely use the following
+//! terminology:
+//!
+//! - "Function": the math operation that does not have an associated precision. E.g. `f(x) = e^x`,
+//!   `f(x) = log(x)`.
+//! - "Routine": A code implementation of a math operation with a specific precision. E.g. `exp`,
+//!   `expf`, `expl`, `log`, `logf`.
+//! - "Operation" / "Op": Something that relates a routine to a function or is otherwise higher
+//!   level. `Op` is also used as the name for generic parameters since it is terse.
+
+use crate::{CheckOutput, Float, TupleCall};
+
+/// An enum representing each possible routine name.
+#[libm_macros::function_enum(BaseName)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Name {}
+
+/// The name without any type specifier, e.g. `sin` and `sinf` both become `sin`.
+#[libm_macros::base_name_enum]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BaseName {}
+
+/// Attributes ascribed to a `libm` routine including signature, type information,
+/// and naming.
+pub trait MathOp {
+    /// The float type used for this operation.
+    type FTy: Float;
+
+    /// The function type representing the signature in a C library.
+    type CFn: Copy;
+
+    /// Arguments passed to the C library function as a tuple. These may include `&mut` return
+    /// values.
+    type CArgs<'a>
+    where
+        Self: 'a;
+
+    /// The type returned by C implementations.
+    type CRet;
+
+    /// The signature of the Rust function as a `fn(...) -> ...` type.
+    type RustFn: Copy;
+
+    /// Arguments passed to the Rust library function as a tuple.
+    ///
+    /// The required `TupleCall` bounds ensure this type can be passed either to the C function or
+    /// to the Rust function.
+    type RustArgs: Copy
+        + TupleCall<Self::RustFn, Output = Self::RustRet>
+        + TupleCall<Self::CFn, Output = Self::RustRet>;
+
+    /// Type returned from the Rust function.
+    type RustRet: CheckOutput<Self::RustArgs>;
+
+    /// The name of this function, including suffix (e.g. `sin`, `sinf`).
+    const NAME: Name;
+
+    /// The name as a string.
+    const NAME_STR: &'static str = Self::NAME.as_str();
+
+    /// The name of the function excluding the type suffix, e.g. `sin` and `sinf` are both `sin`.
+    const BASE_NAME: BaseName = Self::NAME.base_name();
+
+    /// The function in `libm` which can be called.
+    const ROUTINE: Self::RustFn;
+}
+
+macro_rules! do_thing {
+    // Matcher for unary functions
+    (
+        fn_name: $fn_name:ident,
+        FTy: $FTy:ty,
+        CFn: $CFn:ty,
+        CArgs: $CArgs:ty,
+        CRet: $CRet:ty,
+        RustFn: $RustFn:ty,
+        RustArgs: $RustArgs:ty,
+        RustRet: $RustRet:ty,
+    ) => {
+        paste::paste! {
+            pub mod $fn_name {
+                use super::*;
+                pub struct Routine;
+
+                impl MathOp for Routine {
+                    type FTy = $FTy;
+                    type CFn = for<'a> $CFn;
+                    type CArgs<'a> = $CArgs where Self: 'a;
+                    type CRet = $CRet;
+                    type RustFn = $RustFn;
+                    type RustArgs = $RustArgs;
+                    type RustRet = $RustRet;
+
+                    const NAME: Name = Name::[< $fn_name:camel >];
+                    const ROUTINE: Self::RustFn = libm::$fn_name;
+                }
+            }
+
+        }
+    };
+}
+
+libm_macros::for_each_function! {
+    callback: do_thing,
+    emit_types: all,
+}

--- a/crates/libm-test/src/test_traits.rs
+++ b/crates/libm-test/src/test_traits.rs
@@ -137,7 +137,7 @@ where
     }
 }
 
-impl<T1, T2, T3> TupleCall<fn(T1, &mut T2, &mut T3)> for (T1,)
+impl<T1, T2, T3> TupleCall<for<'a> fn(T1, &'a mut T2, &'a mut T3)> for (T1,)
 where
     T1: fmt::Debug,
     T2: fmt::Debug + Default,
@@ -145,7 +145,7 @@ where
 {
     type Output = (T2, T3);
 
-    fn call(self, f: fn(T1, &mut T2, &mut T3)) -> Self::Output {
+    fn call(self, f: for<'a> fn(T1, &'a mut T2, &'a mut T3)) -> Self::Output {
         let mut t2 = T2::default();
         let mut t3 = T3::default();
         f(self.0, &mut t2, &mut t3);

--- a/crates/libm-test/tests/check_coverage.rs
+++ b/crates/libm-test/tests/check_coverage.rs
@@ -22,12 +22,6 @@ const ALLOWED_SKIPS: &[&str] = &[
 macro_rules! callback {
     (
         fn_name: $name:ident,
-        CFn: $_CFn:ty,
-        CArgs: $_CArgs:ty,
-        CRet: $_CRet:ty,
-        RustFn: $_RustFn:ty,
-        RustArgs: $_RustArgs:ty,
-        RustRet: $_RustRet:ty,
         extra: [$push_to:ident],
     ) => {
         $push_to.push(stringify!($name));


### PR DESCRIPTION
This allows us to move a lot of logic out of macros and into generic functions, which is a nice cleanup and much better for usability.