### PR TITLE
Add some more basic docstrings

### DIFF
--- a/src/math/exp10.rs
+++ b/src/math/exp10.rs
@@ -6,6 +6,7 @@ const P10: &[f64] = &[
     1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
 ];
 
+/// Calculates 10 raised to the power of `x` (f64).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp10(x: f64) -> f64 {
     let (mut y, n) = modf(x);

--- a/src/math/exp10f.rs
+++ b/src/math/exp10f.rs
@@ -5,7 +5,7 @@ const LN10_F64: f64 = 3.32192809488736234787031942948939;
 const P10: &[f32] =
     &[1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7];
 
-    /// Calculates 10 raised to the power of `x` (f32).
+/// Calculates 10 raised to the power of `x` (f32).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp10f(x: f32) -> f32 {
     let (mut y, n) = modff(x);

--- a/src/math/exp10f.rs
+++ b/src/math/exp10f.rs
@@ -5,6 +5,7 @@ const LN10_F64: f64 = 3.32192809488736234787031942948939;
 const P10: &[f32] =
     &[1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7];
 
+    /// Calculates 10 raised to the power of `x` (f32).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp10f(x: f32) -> f32 {
     let (mut y, n) = modff(x);

--- a/src/math/lgamma.rs
+++ b/src/math/lgamma.rs
@@ -1,5 +1,6 @@
 use super::lgamma_r;
 
+/// The natural logarithm of the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f64).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgamma(x: f64) -> f64 {
     lgamma_r(x).0

--- a/src/math/lgamma.rs
+++ b/src/math/lgamma.rs
@@ -1,6 +1,7 @@
 use super::lgamma_r;
 
-/// The natural logarithm of the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f64).
+/// The natural logarithm of the
+/// [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f64).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgamma(x: f64) -> f64 {
     lgamma_r(x).0

--- a/src/math/lgammaf.rs
+++ b/src/math/lgammaf.rs
@@ -1,6 +1,7 @@
 use super::lgammaf_r;
 
-/// The natural logarithm of the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f32).
+/// The natural logarithm of the
+/// [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f32).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgammaf(x: f32) -> f32 {
     lgammaf_r(x).0

--- a/src/math/lgammaf.rs
+++ b/src/math/lgammaf.rs
@@ -1,5 +1,6 @@
 use super::lgammaf_r;
 
+/// The natural logarithm of the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f32).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lgammaf(x: f32) -> f32 {
     lgammaf_r(x).0

--- a/src/math/tgamma.rs
+++ b/src/math/tgamma.rs
@@ -130,6 +130,7 @@ fn s(x: f64) -> f64 {
     return num / den;
 }
 
+/// The [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f64).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tgamma(mut x: f64) -> f64 {
     let u: u64 = x.to_bits();

--- a/src/math/tgammaf.rs
+++ b/src/math/tgammaf.rs
@@ -1,5 +1,6 @@
 use super::tgamma;
 
+/// The [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f64).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tgammaf(x: f32) -> f32 {
     tgamma(x as f64) as f32

--- a/src/math/tgammaf.rs
+++ b/src/math/tgammaf.rs
@@ -1,6 +1,6 @@
 use super::tgamma;
 
-/// The [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f64).
+/// The [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) (f32).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tgammaf(x: f32) -> f32 {
     tgamma(x as f64) as f32

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -1,7 +1,7 @@
 use core::f64;
 
 /// Rounds the number toward 0 to the closest integral value (f64).
-/// 
+///
 /// This effectively removes the decimal part of the number, leaving the integral part.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn trunc(x: f64) -> f64 {

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -1,5 +1,6 @@
 use core::f64;
 
+/// Rounds the number toward 0 to an integral value (f64).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn trunc(x: f64) -> f64 {
     select_implementation! {

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -1,6 +1,8 @@
 use core::f64;
 
-/// Rounds the number toward 0 to an integral value (f64).
+/// Rounds the number toward 0 to the closest integral value (f64).
+/// 
+/// This effectively removes the decimal part of the number, leaving the integral part.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn trunc(x: f64) -> f64 {
     select_implementation! {

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -1,5 +1,6 @@
 use core::f32;
 
+/// Rounds the number toward 0 to an integral value (f32).
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn truncf(x: f32) -> f32 {
     select_implementation! {

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -1,6 +1,8 @@
 use core::f32;
 
-/// Rounds the number toward 0 to an integral value (f32).
+/// Rounds the number toward 0 to the closest integral value (f32).
+/// 
+/// This effectively removes the decimal part of the number, leaving the integral part.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn truncf(x: f32) -> f32 {
     select_implementation! {

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -1,7 +1,7 @@
 use core::f32;
 
 /// Rounds the number toward 0 to the closest integral value (f32).
-/// 
+///
 /// This effectively removes the decimal part of the number, leaving the integral part.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn truncf(x: f32) -> f32 {


### PR DESCRIPTION
Adds docstrings to `tgamma`, `tgammaf`, `lgamma`, `lgammaf`, `trunc`, `truncf`, `exp10`, and `exp10f`. Related to #336.