### PR TITLE
Change default ULP to use enum matching

### DIFF
--- a/crates/libm-test/benches/random.rs
+++ b/crates/libm-test/benches/random.rs
@@ -49,8 +49,7 @@ where
 {
     let name = Op::NAME;
 
-    let ulp = libm_test::musl_allowed_ulp(name);
-    let ctx = CheckCtx::new(ulp, Op::IDENTIFIER, CheckBasis::Musl);
+    let ctx = CheckCtx::new(Op::IDENTIFIER, CheckBasis::Musl);
     let benchvec: Vec<_> =
         random::get_test_cases::<Op::RustArgs>(&ctx).take(BENCH_ITER_ITEMS).collect();
 

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -7,7 +7,7 @@ mod test_traits;
 
 pub use libm::support::{Float, Int};
 pub use op::{BaseName, Identifier, MathOp};
-pub use precision::{MaybeOverride, SpecialCase, multiprec_allowed_ulp, musl_allowed_ulp};
+pub use precision::{MaybeOverride, SpecialCase, default_ulp};
 pub use test_traits::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, Hex, TupleCall};
 
 /// Result type for tests is usually from `anyhow`. Most times there is no success value to

--- a/crates/libm-test/src/test_traits.rs
+++ b/crates/libm-test/src/test_traits.rs
@@ -29,15 +29,18 @@ pub struct CheckCtx {
 }
 
 impl CheckCtx {
-    pub fn new(ulp: u32, fn_ident: Identifier, basis: CheckBasis) -> Self {
-        Self {
-            ulp,
+    /// Create a new check context, using the default ULP for the function.
+    pub fn new(fn_ident: Identifier, basis: CheckBasis) -> Self {
+        let mut ret = Self {
+            ulp: 0,
             fn_ident,
             fn_name: fn_ident.as_str(),
             base_name: fn_ident.base_name(),
             base_name_str: fn_ident.base_name().as_str(),
             basis,
-        }
+        };
+        ret.ulp = crate::default_ulp(&ret);
+        ret
     }
 }
 

--- a/crates/libm-test/tests/compare_built_musl.rs
+++ b/crates/libm-test/tests/compare_built_musl.rs
@@ -10,9 +10,7 @@
 #![cfg(feature = "build-musl")]
 
 use libm_test::gen::{CachedInput, random};
-use libm_test::{
-    CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleCall, musl_allowed_ulp,
-};
+use libm_test::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleCall};
 
 macro_rules! musl_rand_tests {
     (
@@ -34,9 +32,7 @@ where
     Op: MathOp,
     CachedInput: GenerateInput<Op::RustArgs>,
 {
-    let name = Op::NAME;
-    let ulp = musl_allowed_ulp(name);
-    let ctx = CheckCtx::new(ulp, Op::IDENTIFIER, CheckBasis::Musl);
+    let ctx = CheckCtx::new(Op::IDENTIFIER, CheckBasis::Musl);
     let cases = random::get_test_cases::<Op::RustArgs>(&ctx);
 
     for input in cases {

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -4,9 +4,7 @@
 
 use libm_test::gen::{CachedInput, random};
 use libm_test::mpfloat::MpOp;
-use libm_test::{
-    CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleCall, multiprec_allowed_ulp,
-};
+use libm_test::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleCall};
 
 /// Implement a test against MPFR with random inputs.
 macro_rules! multiprec_rand_tests {
@@ -29,11 +27,8 @@ where
     Op: MathOp + MpOp,
     CachedInput: GenerateInput<Op::RustArgs>,
 {
-    let name = Op::NAME;
-
-    let ulp = multiprec_allowed_ulp(name);
     let mut mp_vals = Op::new_mp();
-    let ctx = CheckCtx::new(ulp, Op::IDENTIFIER, CheckBasis::Mpfr);
+    let ctx = CheckCtx::new(Op::IDENTIFIER, CheckBasis::Mpfr);
     let cases = random::get_test_cases::<Op::RustArgs>(&ctx);
 
     for input in cases {


### PR DESCRIPTION
Migrate from string to enum matching and tie this to `CheckCtx::new`, so no tests need to explicitly set ULP.