### PR TITLE
Change the `multiprec_` prefix to `mp_`

### DIFF
--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -15,7 +15,7 @@ pub struct SpecialCase;
 const MUSL_DEFAULT_ULP: u32 = 2;
 
 /// Default ULP allowed to differ from multiprecision (i.e. infinite) results.
-const MULTIPREC_DEFAULT_ULP: u32 = 1;
+const MP_DEFAULT_ULP: u32 = 1;
 
 /// ULP allowed to differ from the results returned by a test basis.
 ///
@@ -52,7 +52,7 @@ pub fn default_ulp(ctx: &CheckCtx) -> u32 {
 
         // Defaults
         (Musl, _) => MUSL_DEFAULT_ULP,
-        (Mpfr, _) => MULTIPREC_DEFAULT_ULP,
+        (Mpfr, _) => MP_DEFAULT_ULP,
     }
 }
 

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -7,7 +7,7 @@ use libm_test::mpfloat::MpOp;
 use libm_test::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleCall};
 
 /// Implement a test against MPFR with random inputs.
-macro_rules! multiprec_rand_tests {
+macro_rules! mp_rand_tests {
     (
         fn_name: $fn_name:ident,
         attrs: [$($meta:meta)*]
@@ -15,7 +15,7 @@ macro_rules! multiprec_rand_tests {
         paste::paste! {
             #[test]
             $(#[$meta])*
-            fn [< multiprec_random_ $fn_name >]() {
+            fn [< mp_random_ $fn_name >]() {
                 test_one::<libm_test::op::$fn_name::Routine>();
             }
         }
@@ -40,7 +40,7 @@ where
 }
 
 libm_macros::for_each_function! {
-    callback: multiprec_rand_tests,
+    callback: mp_rand_tests,
     attributes: [
         // Also an assertion failure on i686: at `MPFR_ASSERTN (! mpfr_erangeflag_p ())`
         #[ignore = "large values are infeasible in MPFR"]


### PR DESCRIPTION
Currently there is a combination of names starting with `multiprecision_`, `mp_` and `multiprec_`. Update so `multiprecision_` is always used when a long form makes sense, `mp_` otherwise (eliminating `multiprec_`).