### PR TITLE
Move some numeric trait logic to default implementations

### DIFF
--- a/crates/libm-test/src/test_traits.rs
+++ b/crates/libm-test/src/test_traits.rs
@@ -314,7 +314,7 @@ where
         // Make sure that the signs are the same before checing ULP to avoid wraparound
         let act_sig = actual.signum();
         let exp_sig = expected.signum();
-        ensure!(act_sig == exp_sig, "mismatched signs {act_sig} {exp_sig}");
+        ensure!(act_sig == exp_sig, "mismatched signs {act_sig:?} {exp_sig:?}");
 
         if actual.is_infinite() ^ expected.is_infinite() {
             bail!("mismatched infinities");

--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -1,4 +1,4 @@
-use core::{fmt, ops};
+use core::{cmp, fmt, ops};
 
 /// Minimal integer implementations needed on all integer types, including wide integers.
 #[allow(dead_code)]
@@ -31,6 +31,8 @@ pub trait MinInt:
 pub trait Int:
     MinInt
     + fmt::Display
+    + fmt::Binary
+    + fmt::LowerHex
     + PartialEq
     + PartialOrd
     + ops::AddAssign
@@ -47,6 +49,9 @@ pub trait Int:
     + ops::Shr<u32, Output = Self>
     + ops::BitXor<Output = Self>
     + ops::BitAnd<Output = Self>
+    + cmp::Ord
+    + CastInto<usize>
+    + CastFrom<u8>
 {
     fn signed(self) -> <Self::Unsigned as MinInt>::OtherSign;
     fn unsigned(self) -> Self::Unsigned;


### PR DESCRIPTION
There are a handful of functions we can move out of the macro and to the numeric traits as default implementations; do that here.

Additionally, add some bounds that make sense for completeness.