### PR TITLE
Use `https:` links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ This crate supports rustc 1.63 and newer.
 ## License
 
 Usage is licensed under the MIT license ([LICENSE-MIT](LICENSE-MIT) or
-http://opensource.org/licenses/MIT).
+https://opensource.org/licenses/MIT).
 
 
 ### Contribution
 
 Contributions are licensed under both the MIT license and the Apache License,
 Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-http://www.apache.org/licenses/LICENSE-2.0). Unless you explicitly state
+https://www.apache.org/licenses/LICENSE-2.0). Unless you explicitly state
 otherwise, any contribution intentionally submitted for inclusion in the work
 by you, as defined in the Apache-2.0 license, shall be dual licensed as
 mentioned, without any additional terms or conditions.


### PR DESCRIPTION
Both `http:` links redirect to the equivalent `https:` URL, so this PR links the `https:` URL directly instead of using the insecure redirect.