### PR TITLE
Fix a bug in `abs_diff`

### DIFF
--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -184,7 +184,7 @@ macro_rules! int_impl {
             }
 
             fn abs_diff(self, other: Self) -> Self {
-                if self < other { other.wrapping_sub(self) } else { self.wrapping_sub(other) }
+                self.abs_diff(other)
             }
 
             int_impl_common!($uty);
@@ -221,7 +221,7 @@ macro_rules! int_impl {
             }
 
             fn abs_diff(self, other: Self) -> $uty {
-                self.wrapping_sub(other).wrapping_abs() as $uty
+                self.abs_diff(other)
             }
 
             int_impl_common!($ity);


### PR DESCRIPTION
These were taken from `compiler-builtins` but the implementation has a bug near the integer limits. Fixed in `compiler-builtins` by using `core`'s implementation at [1], this is the corresponding fix for `libm`.

[1]: https://github.com/rust-lang/compiler-builtins/pull/736