### PR TITLE
Introduce helper types for accessing trait items

### DIFF
--- a/crates/libm-test/benches/random.rs
+++ b/crates/libm-test/benches/random.rs
@@ -26,7 +26,7 @@ macro_rules! musl_rand_benches {
 
                 #[cfg(feature = "build-musl")]
                 let musl_extra = MuslExtra {
-                    musl_fn: Some(musl_math_sys::$fn_name as <Op as MathOp>::CFn),
+                    musl_fn: Some(musl_math_sys::$fn_name as libm_test::CFn<Op>),
                     skip_on_i586: $skip_on_i586
                 };
 

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -5,8 +5,8 @@ pub mod op;
 mod precision;
 mod test_traits;
 
-pub use libm::support::{Float, Int};
-pub use op::{BaseName, Identifier, MathOp};
+pub use libm::support::{Float, Int, IntTy};
+pub use op::{BaseName, CFn, FTy, Identifier, MathOp, RustFn, RustRet};
 pub use precision::{MaybeOverride, SpecialCase, default_ulp};
 pub use test_traits::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, Hex, TupleCall};
 

--- a/crates/libm-test/src/op.rs
+++ b/crates/libm-test/src/op.rs
@@ -70,6 +70,15 @@ pub trait MathOp {
     const ROUTINE: Self::RustFn;
 }
 
+/// Access the associated `FTy` type from an op (helper to avoid ambiguous associated types).
+pub type FTy<Op> = <Op as MathOp>::FTy;
+/// Access the associated `CFn` type from an op (helper to avoid ambiguous associated types).
+pub type CFn<Op> = <Op as MathOp>::CFn;
+/// Access the associated `RustFn` type from an op (helper to avoid ambiguous associated types).
+pub type RustFn<Op> = <Op as MathOp>::RustFn;
+/// Access the associated `RustRet` type from an op (helper to avoid ambiguous associated types).
+pub type RustRet<Op> = <Op as MathOp>::RustRet;
+
 macro_rules! do_thing {
     // Matcher for unary functions
     (

--- a/src/math/support/float_traits.rs
+++ b/src/math/support/float_traits.rs
@@ -153,6 +153,10 @@ pub trait Float:
     }
 }
 
+/// Access the associated `Int` type from a float (helper to avoid ambiguous associated types).
+#[allow(dead_code)]
+pub type IntTy<F> = <F as Float>::Int;
+
 macro_rules! float_impl {
     ($ty:ident, $ity:ident, $sity:ident, $expty:ident, $bits:expr, $significand_bits:expr) => {
         impl Float for $ty {

--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -26,6 +26,10 @@ pub trait MinInt:
     const MAX: Self;
 }
 
+/// Access the associated `OtherSign` type from an int (helper to avoid ambiguous associated
+/// types).
+pub type OtherSign<I> = <I as MinInt>::OtherSign;
+
 /// Trait for some basic operations on integers
 #[allow(dead_code)]
 pub trait Int:
@@ -53,7 +57,7 @@ pub trait Int:
     + CastInto<usize>
     + CastFrom<u8>
 {
-    fn signed(self) -> <Self::Unsigned as MinInt>::OtherSign;
+    fn signed(self) -> OtherSign<Self::Unsigned>;
     fn unsigned(self) -> Self::Unsigned;
     fn from_unsigned(unsigned: Self::Unsigned) -> Self;
     fn abs(self) -> Self;

--- a/src/math/support/mod.rs
+++ b/src/math/support/mod.rs
@@ -4,7 +4,8 @@ mod float_traits;
 mod hex_float;
 mod int_traits;
 
-pub use float_traits::Float;
+#[allow(unused_imports)]
+pub use float_traits::{Float, IntTy};
 #[allow(unused_imports)]
 pub use hex_float::{hf32, hf64};
 pub use int_traits::{CastFrom, CastInto, DInt, HInt, Int, MinInt};


### PR DESCRIPTION
The ambiguous associated types error sometimes fires in cases where it shouldn't be ambiguous ([1]), which can make things clunky when working with chained associated types (e.g. `Op::FTy::Int::*` does not work). Add helper types that we can use instead of the full syntax.

There aren't too many cases in-crate now but this is relevant for some open PRs.

[1]: https://github.com/rust-lang/rust/issues/38078