### PR TITLE
Rename associated type helpers, add `OpITy`

### DIFF
--- a/crates/libm-test/benches/random.rs
+++ b/crates/libm-test/benches/random.rs
@@ -26,7 +26,7 @@ macro_rules! musl_rand_benches {
 
                 #[cfg(feature = "build-musl")]
                 let musl_extra = MuslExtra {
-                    musl_fn: Some(musl_math_sys::$fn_name as libm_test::CFn<Op>),
+                    musl_fn: Some(musl_math_sys::$fn_name as libm_test::OpCFn<Op>),
                     skip_on_i586: $skip_on_i586
                 };
 

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -6,7 +6,7 @@ mod precision;
 mod test_traits;
 
 pub use libm::support::{Float, Int, IntTy};
-pub use op::{BaseName, CFn, FTy, Identifier, MathOp, RustFn, RustRet};
+pub use op::{BaseName, Identifier, MathOp, OpCFn, OpFTy, OpRustFn, OpRustRet};
 pub use precision::{MaybeOverride, SpecialCase, default_ulp};
 pub use test_traits::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, Hex, TupleCall};
 

--- a/crates/libm-test/src/op.rs
+++ b/crates/libm-test/src/op.rs
@@ -71,13 +71,15 @@ pub trait MathOp {
 }
 
 /// Access the associated `FTy` type from an op (helper to avoid ambiguous associated types).
-pub type FTy<Op> = <Op as MathOp>::FTy;
+pub type OpFTy<Op> = <Op as MathOp>::FTy;
+/// Access the associated `FTy::Int` type from an op (helper to avoid ambiguous associated types).
+pub type OpITy<Op> = <<Op as MathOp>::FTy as Float>::Int;
 /// Access the associated `CFn` type from an op (helper to avoid ambiguous associated types).
-pub type CFn<Op> = <Op as MathOp>::CFn;
+pub type OpCFn<Op> = <Op as MathOp>::CFn;
 /// Access the associated `RustFn` type from an op (helper to avoid ambiguous associated types).
-pub type RustFn<Op> = <Op as MathOp>::RustFn;
+pub type OpRustFn<Op> = <Op as MathOp>::RustFn;
 /// Access the associated `RustRet` type from an op (helper to avoid ambiguous associated types).
-pub type RustRet<Op> = <Op as MathOp>::RustRet;
+pub type OpRustRet<Op> = <Op as MathOp>::RustRet;
 
 macro_rules! do_thing {
     // Matcher for unary functions


### PR DESCRIPTION
Change the names to make them less ambiguous. Additionally add `OpITy` for accessing the same-sized integer of an operation's float type.