### PR TITLE
Change trait bounds from `Iterator` to `ExactSizeIterator`

### DIFF
--- a/crates/libm-test/src/gen.rs
+++ b/crates/libm-test/src/gen.rs
@@ -12,61 +12,61 @@ pub struct CachedInput {
 }
 
 impl GenerateInput<(f32,)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f32,)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f32,)> {
         self.inputs_f32.iter().map(|f| (f.0,))
     }
 }
 
 impl GenerateInput<(f32, f32)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f32, f32)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f32, f32)> {
         self.inputs_f32.iter().map(|f| (f.0, f.1))
     }
 }
 
 impl GenerateInput<(i32, f32)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (i32, f32)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (i32, f32)> {
         self.inputs_i32.iter().zip(self.inputs_f32.iter()).map(|(i, f)| (i.0, f.0))
     }
 }
 
 impl GenerateInput<(f32, i32)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f32, i32)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f32, i32)> {
         GenerateInput::<(i32, f32)>::get_cases(self).map(|(i, f)| (f, i))
     }
 }
 
 impl GenerateInput<(f32, f32, f32)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f32, f32, f32)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f32, f32, f32)> {
         self.inputs_f32.iter().copied()
     }
 }
 
 impl GenerateInput<(f64,)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f64,)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f64,)> {
         self.inputs_f64.iter().map(|f| (f.0,))
     }
 }
 
 impl GenerateInput<(f64, f64)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f64, f64)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f64, f64)> {
         self.inputs_f64.iter().map(|f| (f.0, f.1))
     }
 }
 
 impl GenerateInput<(i32, f64)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (i32, f64)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (i32, f64)> {
         self.inputs_i32.iter().zip(self.inputs_f64.iter()).map(|(i, f)| (i.0, f.0))
     }
 }
 
 impl GenerateInput<(f64, i32)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f64, i32)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f64, i32)> {
         GenerateInput::<(i32, f64)>::get_cases(self).map(|(i, f)| (f, i))
     }
 }
 
 impl GenerateInput<(f64, f64, f64)> for CachedInput {
-    fn get_cases(&self) -> impl Iterator<Item = (f64, f64, f64)> {
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = (f64, f64, f64)> {
         self.inputs_f64.iter().copied()
     }
 }

--- a/crates/libm-test/src/gen/random.rs
+++ b/crates/libm-test/src/gen/random.rs
@@ -106,7 +106,7 @@ fn make_test_cases(ntests: usize) -> CachedInput {
 }
 
 /// Create a test case iterator.
-pub fn get_test_cases<RustArgs>(ctx: &CheckCtx) -> impl Iterator<Item = RustArgs>
+pub fn get_test_cases<RustArgs>(ctx: &CheckCtx) -> impl ExactSizeIterator<Item = RustArgs>
 where
     CachedInput: GenerateInput<RustArgs>,
 {

--- a/crates/libm-test/src/test_traits.rs
+++ b/crates/libm-test/src/test_traits.rs
@@ -55,7 +55,7 @@ pub enum CheckBasis {
 
 /// Implement this on types that can generate a sequence of tuples for test input.
 pub trait GenerateInput<TupleArgs> {
-    fn get_cases(&self) -> impl Iterator<Item = TupleArgs>;
+    fn get_cases(&self) -> impl ExactSizeIterator<Item = TupleArgs>;
 }
 
 /// Trait for calling a function with a tuple as arguments.


### PR DESCRIPTION
It is convenient to be able to check remaining items, which shouldn't be a problem in most cases.