### PR TITLE
Introduce generic `abs` and `copysign`

### DIFF
--- a/src/math/copysign.rs
+++ b/src/math/copysign.rs
@@ -4,9 +4,5 @@
 /// first argument, `x`, and the sign of its second argument, `y`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn copysign(x: f64, y: f64) -> f64 {
-    let mut ux = x.to_bits();
-    let uy = y.to_bits();
-    ux &= (!0) >> 1;
-    ux |= uy & (1 << 63);
-    f64::from_bits(ux)
+    super::generic::copysign(x, y)
 }

--- a/src/math/copysignf.rs
+++ b/src/math/copysignf.rs
@@ -4,9 +4,5 @@
 /// first argument, `x`, and the sign of its second argument, `y`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn copysignf(x: f32, y: f32) -> f32 {
-    let mut ux = x.to_bits();
-    let uy = y.to_bits();
-    ux &= 0x7fffffff;
-    ux |= uy & 0x80000000;
-    f32::from_bits(ux)
+    super::generic::copysign(x, y)
 }

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -9,7 +9,7 @@ pub fn fabs(x: f64) -> f64 {
         args: x,
     }
 
-    f64::from_bits(x.to_bits() & (u64::MAX / 2))
+    super::generic::abs(x)
 }
 
 #[cfg(test)]

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -9,7 +9,7 @@ pub fn fabsf(x: f32) -> f32 {
         args: x,
     }
 
-    f32::from_bits(x.to_bits() & 0x7fffffff)
+    super::generic::abs(x)
 }
 
 // PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520

--- a/src/math/generic/abs.rs
+++ b/src/math/generic/abs.rs
@@ -1,0 +1,6 @@
+use super::super::Float;
+
+/// Absolute value.
+pub fn abs<F: Float>(x: F) -> F {
+    x.abs()
+}

--- a/src/math/generic/copysign.rs
+++ b/src/math/generic/copysign.rs
@@ -1,0 +1,10 @@
+use super::super::Float;
+
+/// Copy the sign of `y` to `x`.
+pub fn copysign<F: Float>(x: F, y: F) -> F {
+    let mut ux = x.to_bits();
+    let uy = y.to_bits();
+    ux &= !F::SIGN_MASK;
+    ux |= uy & (F::SIGN_MASK);
+    F::from_bits(ux)
+}

--- a/src/math/generic/mod.rs
+++ b/src/math/generic/mod.rs
@@ -1,0 +1,5 @@
+mod abs;
+mod copysign;
+
+pub use abs::abs;
+pub use copysign::copysign;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -87,6 +87,7 @@ mod support;
 mod arch;
 mod expo2;
 mod fenv;
+mod generic;
 mod k_cos;
 mod k_cosf;
 mod k_expo2;


### PR DESCRIPTION
Add generic versions of `abs` and `copysign`, which will provide an entrypoint for adding `f16` and `f128`. Since this implementation is identical to the existing type-specific implementations, make use of it for `f32` and `f64`.

Split off from https://github.com/rust-lang/libm/pull/320