### PR TITLE
macros: Always emit `f16_enabled` and `f128_enabled` attributes

### DIFF
--- a/crates/libm-macros/tests/basic.rs
+++ b/crates/libm-macros/tests/basic.rs
@@ -1,3 +1,5 @@
+#![feature(f16)]
+#![feature(f128)]
 // `STATUS_DLL_NOT_FOUND` on i686 MinGW, not worth looking into.
 #![cfg(not(all(target_arch = "x86", target_os = "windows", target_env = "gnu")))]
 
@@ -11,11 +13,11 @@ macro_rules! basic {
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
         RustRet: $RustRet:ty,
-        attrs: [$($meta:meta)*]
+        attrs: [$($attr:meta),*],
         extra: [$($extra_tt:tt)*],
         fn_extra: $fn_extra:expr,
     ) => {
-        $(#[$meta])*
+        $(#[$attr])*
         mod $fn_name {
             #[allow(unused)]
             type FTy= $FTy;
@@ -60,7 +62,9 @@ mod test_basic {
 macro_rules! basic_no_extra {
     (
         fn_name: $fn_name:ident,
+        attrs: [$($attr:meta),*],
     ) => {
+        $(#[$attr])*
         mod $fn_name {}
     };
 }
@@ -85,7 +89,9 @@ macro_rules! specified_types {
         fn_name: $fn_name:ident,
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
+        attrs: [$($attr:meta),*],
     ) => {
+        $(#[$attr])*
         mod $fn_name {
             #[allow(unused)]
             type RustFnTy = $RustFn;

--- a/crates/libm-test/benches/random.rs
+++ b/crates/libm-test/benches/random.rs
@@ -18,9 +18,11 @@ struct MuslExtra<F> {
 macro_rules! musl_rand_benches {
     (
         fn_name: $fn_name:ident,
+        attrs: [$($attr:meta),*],
         fn_extra: $skip_on_i586:expr,
     ) => {
         paste::paste! {
+            $(#[$attr])*
             fn [< musl_bench_ $fn_name >](c: &mut Criterion) {
                 type Op = libm_test::op::$fn_name::Routine;
 
@@ -113,9 +115,11 @@ libm_macros::for_each_function! {
 macro_rules! run_callback {
     (
         fn_name: $fn_name:ident,
+        attrs: [$($attr:meta),*],
         extra: [$criterion:ident],
     ) => {
         paste::paste! {
+            $(#[$attr])*
             [< musl_bench_ $fn_name >](&mut $criterion)
         }
     };

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(f16_enabled, feature(f16))]
+#![cfg_attr(f128_enabled, feature(f128))]
 #![allow(clippy::unusual_byte_groupings)] // sometimes we group by sign_exp_sig
 
 pub mod domain;

--- a/crates/libm-test/src/mpfloat.rs
+++ b/crates/libm-test/src/mpfloat.rs
@@ -50,9 +50,11 @@ macro_rules! impl_mp_op {
     (
         fn_name: $fn_name:ident,
         RustFn: fn($_fty:ty,) -> $_ret:ty,
+        attrs: [$($attr:meta),*],
         fn_extra: $fn_name_normalized:expr,
     ) => {
         paste::paste! {
+            $(#[$attr])*
             impl MpOp for crate::op::$fn_name::Routine {
                 type MpTy = MpFloat;
 
@@ -72,9 +74,11 @@ macro_rules! impl_mp_op {
     (
         fn_name: $fn_name:ident,
         RustFn: fn($_fty:ty, $_fty2:ty,) -> $_ret:ty,
+        attrs: [$($attr:meta),*],
         fn_extra: $fn_name_normalized:expr,
     ) => {
         paste::paste! {
+            $(#[$attr])*
             impl MpOp for crate::op::$fn_name::Routine {
                 type MpTy = (MpFloat, MpFloat);
 
@@ -95,9 +99,11 @@ macro_rules! impl_mp_op {
     (
         fn_name: $fn_name:ident,
         RustFn: fn($_fty:ty, $_fty2:ty, $_fty3:ty,) -> $_ret:ty,
+        attrs: [$($attr:meta),*],
         fn_extra: $fn_name_normalized:expr,
     ) => {
         paste::paste! {
+            $(#[$attr])*
             impl MpOp for crate::op::$fn_name::Routine {
                 type MpTy = (MpFloat, MpFloat, MpFloat);
 

--- a/crates/libm-test/src/op.rs
+++ b/crates/libm-test/src/op.rs
@@ -112,8 +112,11 @@ macro_rules! do_thing {
         RustFn: $RustFn:ty,
         RustArgs: $RustArgs:ty,
         RustRet: $RustRet:ty,
+        attrs: [$($attr:meta),*],
+
     ) => {
         paste::paste! {
+            $(#[$attr])*
             pub mod $fn_name {
                 use super::*;
                 pub struct Routine;

--- a/crates/libm-test/tests/check_coverage.rs
+++ b/crates/libm-test/tests/check_coverage.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 macro_rules! callback {
     (
         fn_name: $name:ident,
+        attrs: [$($attr:meta),*],
         extra: [$set:ident],
     ) => {
         let name = stringify!($name);

--- a/crates/libm-test/tests/compare_built_musl.rs
+++ b/crates/libm-test/tests/compare_built_musl.rs
@@ -15,11 +15,11 @@ use libm_test::{CheckBasis, CheckCtx, CheckOutput, GenerateInput, MathOp, TupleC
 macro_rules! musl_rand_tests {
     (
         fn_name: $fn_name:ident,
-        attrs: [$($meta:meta)*]
+        attrs: [$($attr:meta),*],
     ) => {
         paste::paste! {
             #[test]
-            $(#[$meta])*
+            $(#[$attr])*
             fn [< musl_random_ $fn_name >]() {
                 test_one::<libm_test::op::$fn_name::Routine>(musl_math_sys::$fn_name);
             }

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -13,11 +13,11 @@ use libm_test::{
 macro_rules! mp_rand_tests {
     (
         fn_name: $fn_name:ident,
-        attrs: [$($meta:meta)*]
+        attrs: [$($attr:meta),*],
     ) => {
         paste::paste! {
             #[test]
-            $(#[$meta])*
+            $(#[$attr])*
             fn [< mp_random_ $fn_name >]() {
                 test_one_random::<libm_test::op::$fn_name::Routine>();
             }
@@ -76,18 +76,18 @@ libm_macros::for_each_function! {
 macro_rules! mp_domain_tests {
     (
         fn_name: $fn_name:ident,
-        attrs: [$($meta:meta)*]
+        attrs: [$($attr:meta),*],
     ) => {
         paste::paste! {
             #[test]
-            $(#[$meta])*
+            $(#[$attr])*
             fn [< mp_edge_case_ $fn_name >]() {
                 type Op = libm_test::op::$fn_name::Routine;
                 domain_test_runner::<Op, _>(edge_cases::get_test_cases::<Op, _>);
             }
 
             #[test]
-            $(#[$meta])*
+            $(#[$attr])*
             fn [< mp_logspace_ $fn_name >]() {
                 type Op = libm_test::op::$fn_name::Routine;
                 domain_test_runner::<Op, _>(domain_logspace::get_test_cases::<Op>);


### PR DESCRIPTION
Once we start addinf `f16` and `f128` routines, we will need to have this cfg for almost all uses of `for_each_function`. Rather than needing to specify this each time, always emit `#[cfg(f16_enabled)]` or `#[cfg(f128_enabled)]` for each function that uses `f16` or `f128`, respectively.