### PR TITLE
Add `copysignf16`, `copysignf128`, `fabsf16`, and `fabsf128`

### DIFF
--- a/crates/libm-macros/src/shared.rs
+++ b/crates/libm-macros/src/shared.rs
@@ -5,6 +5,13 @@ use std::sync::LazyLock;
 
 const ALL_OPERATIONS_NESTED: &[(FloatTy, Signature, Option<Signature>, &[&str])] = &[
     (
+        // `fn(f16) -> f16`
+        FloatTy::F16,
+        Signature { args: &[Ty::F16], returns: &[Ty::F16] },
+        None,
+        &["fabsf16"],
+    ),
+    (
         // `fn(f32) -> f32`
         FloatTy::F32,
         Signature { args: &[Ty::F32], returns: &[Ty::F32] },
@@ -27,6 +34,20 @@ const ALL_OPERATIONS_NESTED: &[(FloatTy, Signature, Option<Signature>, &[&str])]
             "log10", "log1p", "log2", "log", "rint", "round", "sin", "sinh", "sqrt", "tan", "tanh",
             "tgamma", "trunc", "y0", "y1",
         ],
+    ),
+    (
+        // `fn(f128) -> f128`
+        FloatTy::F128,
+        Signature { args: &[Ty::F128], returns: &[Ty::F128] },
+        None,
+        &["fabsf128"],
+    ),
+    (
+        // `(f16, f16) -> f16`
+        FloatTy::F16,
+        Signature { args: &[Ty::F16, Ty::F16], returns: &[Ty::F16] },
+        None,
+        &["copysignf16"],
     ),
     (
         // `(f32, f32) -> f32`
@@ -63,6 +84,13 @@ const ALL_OPERATIONS_NESTED: &[(FloatTy, Signature, Option<Signature>, &[&str])]
             "pow",
             "remainder",
         ],
+    ),
+    (
+        // `(f128, f128) -> f128`
+        FloatTy::F128,
+        Signature { args: &[Ty::F128, Ty::F128], returns: &[Ty::F128] },
+        None,
+        &["copysignf128"],
     ),
     (
         // `(f32, f32, f32) -> f32`

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 default = ["unstable-float"]
 
 # Propagated from libm because this affects which functions we test.
-unstable-float = ["libm/unstable-float"]
+unstable-float = ["libm/unstable-float", "rug?/nightly-float"]
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.

--- a/crates/libm-test/src/domain.rs
+++ b/crates/libm-test/src/domain.rs
@@ -187,3 +187,15 @@ impl HasDomain<f32> for crate::op::lgammaf_r::Routine {
 impl HasDomain<f64> for crate::op::lgamma_r::Routine {
     const DOMAIN: Domain<f64> = Domain::<f64>::LGAMMA;
 }
+
+/* Not all `f16` and `f128` functions exist yet so we can't easily use the macros. */
+
+#[cfg(f16_enabled)]
+impl HasDomain<f16> for crate::op::fabsf16::Routine {
+    const DOMAIN: Domain<f16> = Domain::<f16>::UNBOUNDED;
+}
+
+#[cfg(f128_enabled)]
+impl HasDomain<f128> for crate::op::fabsf128::Routine {
+    const DOMAIN: Domain<f128> = Domain::<f128>::UNBOUNDED;
+}

--- a/crates/libm-test/src/gen/extensive.rs
+++ b/crates/libm-test/src/gen/extensive.rs
@@ -118,8 +118,12 @@ macro_rules! impl_extensive_input {
     };
 }
 
+#[cfg(f16_enabled)]
+impl_extensive_input!(f16);
 impl_extensive_input!(f32);
 impl_extensive_input!(f64);
+#[cfg(f128_enabled)]
+impl_extensive_input!(f128);
 
 /// Create a test case iterator for extensive inputs.
 pub fn get_test_cases<Op>(

--- a/crates/libm-test/src/gen/random.rs
+++ b/crates/libm-test/src/gen/random.rs
@@ -94,8 +94,12 @@ macro_rules! impl_random_input {
     };
 }
 
+#[cfg(f16_enabled)]
+impl_random_input!(f16);
 impl_random_input!(f32);
 impl_random_input!(f64);
+#[cfg(f128_enabled)]
+impl_random_input!(f128);
 
 /// Create a test case iterator.
 pub fn get_test_cases<RustArgs: RandomInput>(

--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -99,6 +99,9 @@ pub trait MaybeOverride<Input> {
     }
 }
 
+#[cfg(f16_enabled)]
+impl MaybeOverride<(f16,)> for SpecialCase {}
+
 impl MaybeOverride<(f32,)> for SpecialCase {
     fn check_float<F: Float>(
         input: (f32,),
@@ -232,6 +235,9 @@ impl MaybeOverride<(f64,)> for SpecialCase {
     }
 }
 
+#[cfg(f128_enabled)]
+impl MaybeOverride<(f128,)> for SpecialCase {}
+
 /// Check NaN bits if the function requires it
 fn maybe_check_nan_bits<F: Float>(actual: F, expected: F, ctx: &CheckCtx) -> Option<TestResult> {
     if !(ctx.base_name == BaseName::Fabs || ctx.base_name == BaseName::Copysign) {
@@ -259,6 +265,19 @@ fn maybe_check_nan_bits<F: Float>(actual: F, expected: F, ctx: &CheckCtx) -> Opt
     }
 }
 
+#[cfg(f16_enabled)]
+impl MaybeOverride<(f16, f16)> for SpecialCase {
+    fn check_float<F: Float>(
+        input: (f16, f16),
+        _actual: F,
+        expected: F,
+        _ulp: &mut u32,
+        ctx: &CheckCtx,
+    ) -> Option<TestResult> {
+        maybe_skip_binop_nan(input, expected, ctx)
+    }
+}
+
 impl MaybeOverride<(f32, f32)> for SpecialCase {
     fn check_float<F: Float>(
         input: (f32, f32),
@@ -274,6 +293,19 @@ impl MaybeOverride<(f32, f32)> for SpecialCase {
 impl MaybeOverride<(f64, f64)> for SpecialCase {
     fn check_float<F: Float>(
         input: (f64, f64),
+        _actual: F,
+        expected: F,
+        _ulp: &mut u32,
+        ctx: &CheckCtx,
+    ) -> Option<TestResult> {
+        maybe_skip_binop_nan(input, expected, ctx)
+    }
+}
+
+#[cfg(f128_enabled)]
+impl MaybeOverride<(f128, f128)> for SpecialCase {
+    fn check_float<F: Float>(
+        input: (f128, f128),
         _actual: F,
         expected: F,
         _ulp: &mut u32,

--- a/crates/libm-test/src/test_traits.rs
+++ b/crates/libm-test/src/test_traits.rs
@@ -303,6 +303,12 @@ where
 
 impl_float!(f32, f64);
 
+#[cfg(f16_enabled)]
+impl_float!(f16);
+
+#[cfg(f128_enabled)]
+impl_float!(f128);
+
 /* trait implementations for compound types */
 
 /// Implement `CheckOutput` for combinations of types.

--- a/crates/libm-test/tests/compare_built_musl.rs
+++ b/crates/libm-test/tests/compare_built_musl.rs
@@ -46,6 +46,8 @@ where
 
 libm_macros::for_each_function! {
     callback: musl_rand_tests,
+    // Musl does not support `f16` and `f128` on all platforms.
+    skip: [copysignf16, copysignf128, fabsf16, fabsf128],
     attributes: [
         #[cfg_attr(x86_no_sse, ignore)] // FIXME(correctness): wrong result on i586
         [exp10, exp10f, exp2, exp2f, rint]

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -130,6 +130,8 @@ libm_macros::for_each_function! {
         atan2f,
         copysign,
         copysignf,
+        copysignf16,
+        copysignf128,
         fdim,
         fdimf,
         fma,

--- a/etc/function-definitions.json
+++ b/etc/function-definitions.json
@@ -136,6 +136,20 @@
         ],
         "type": "f32"
     },
+    "copysignf128": {
+        "sources": [
+            "src/math/copysignf128.rs",
+            "src/math/generic/copysign.rs"
+        ],
+        "type": "f128"
+    },
+    "copysignf16": {
+        "sources": [
+            "src/math/copysignf16.rs",
+            "src/math/generic/copysign.rs"
+        ],
+        "type": "f16"
+    },
     "cos": {
         "sources": [
             "src/libm_helper.rs",
@@ -257,6 +271,20 @@
             "src/math/generic/fabs.rs"
         ],
         "type": "f32"
+    },
+    "fabsf128": {
+        "sources": [
+            "src/math/fabsf128.rs",
+            "src/math/generic/fabs.rs"
+        ],
+        "type": "f128"
+    },
+    "fabsf16": {
+        "sources": [
+            "src/math/fabsf16.rs",
+            "src/math/generic/fabs.rs"
+        ],
+        "type": "f16"
     },
     "fdim": {
         "sources": [

--- a/etc/function-list.txt
+++ b/etc/function-list.txt
@@ -19,6 +19,8 @@ ceil
 ceilf
 copysign
 copysignf
+copysignf128
+copysignf16
 cos
 cosf
 cosh
@@ -37,6 +39,8 @@ expm1
 expm1f
 fabs
 fabsf
+fabsf128
+fabsf16
 fdim
 fdimf
 floor

--- a/etc/update-api-list.py
+++ b/etc/update-api-list.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, TypeAlias
 
 ETC_DIR = Path(__file__).parent
+ROOT_DIR = ETC_DIR.parent
 
 IndexTy: TypeAlias = dict[str, dict[str, Any]]
 """Type of the `index` item in rustdoc's JSON output"""
@@ -56,10 +57,12 @@ class Crate:
                 "--edition=2021",
                 "--document-private-items",
                 "--output-format=json",
+                "--cfg=f16_enabled",
+                "--cfg=f128_enabled",
                 "-Zunstable-options",
                 "-o-",
             ],
-            cwd=ETC_DIR.parent,
+            cwd=ROOT_DIR,
             text=True,
         )
         j = json.loads(j)
@@ -105,8 +108,8 @@ class Crate:
 
         # A lot of the `arch` module is often configured out so doesn't show up in docs. Use
         # string matching as a fallback.
-        for fname in glob("src/math/arch/**.rs", root_dir=ETC_DIR.parent):
-            contents = Path(fname).read_text()
+        for fname in glob("src/math/arch/**.rs", root_dir=ROOT_DIR):
+            contents = (ROOT_DIR.joinpath(fname)).read_text()
 
             for name in self.public_functions:
                 if f"fn {name}" in contents:

--- a/src/libm_helper.rs
+++ b/src/libm_helper.rs
@@ -30,7 +30,7 @@ macro_rules! libm_helper {
         }
     };
 
-    ({$($func:tt);*}) => {
+    ({$($func:tt;)*}) => {
         $(
             libm_helper! { $func }
         )*
@@ -103,7 +103,7 @@ libm_helper! {
         (fn trunc(x: f32) -> (f32);                 => truncf);
         (fn y0(x: f32) -> (f32);                    => y0f);
         (fn y1(x: f32) -> (f32);                    => y1f);
-        (fn yn(n: i32, x: f32) -> (f32);            => ynf)
+        (fn yn(n: i32, x: f32) -> (f32);            => ynf);
     }
 }
 
@@ -166,6 +166,24 @@ libm_helper! {
         (fn trunc(x: f64) -> (f64);                 => trunc);
         (fn y0(x: f64) -> (f64);                    => y0);
         (fn y1(x: f64) -> (f64);                    => y1);
-        (fn yn(n: i32, x: f64) -> (f64);            => yn)
+        (fn yn(n: i32, x: f64) -> (f64);            => yn);
+    }
+}
+
+#[cfg(f16_enabled)]
+libm_helper! {
+    f16,
+    funcs: {
+        (fn copysign(x: f16, y: f16) -> (f16);      => copysignf16);
+        (fn fabs(x: f16) -> (f16);                  => fabsf16);
+    }
+}
+
+#[cfg(f128_enabled)]
+libm_helper! {
+    f128,
+    funcs: {
+        (fn copysign(x: f128, y: f128) -> (f128);   => copysignf128);
+        (fn fabs(x: f128) -> (f128);                => fabsf128);
     }
 }

--- a/src/math/copysignf128.rs
+++ b/src/math/copysignf128.rs
@@ -1,0 +1,8 @@
+/// Sign of Y, magnitude of X (f128)
+///
+/// Constructs a number with the magnitude (absolute value) of its
+/// first argument, `x`, and the sign of its second argument, `y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn copysignf128(x: f128, y: f128) -> f128 {
+    super::generic::copysign(x, y)
+}

--- a/src/math/copysignf16.rs
+++ b/src/math/copysignf16.rs
@@ -1,0 +1,8 @@
+/// Sign of Y, magnitude of X (f16)
+///
+/// Constructs a number with the magnitude (absolute value) of its
+/// first argument, `x`, and the sign of its second argument, `y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn copysignf16(x: f16, y: f16) -> f16 {
+    super::generic::copysign(x, y)
+}

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -1,4 +1,5 @@
 /// Absolute value (magnitude) (f32)
+///
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]

--- a/src/math/fabsf128.rs
+++ b/src/math/fabsf128.rs
@@ -1,11 +1,11 @@
-/// Absolute value (magnitude) (f64)
+/// Absolute value (magnitude) (f128)
 ///
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fabs(x: f64) -> f64 {
+pub fn fabsf128(x: f128) -> f128 {
     select_implementation! {
-        name: fabs,
+        name: fabsf,
         use_intrinsic: target_arch = "wasm32",
         args: x,
     }
@@ -13,25 +13,27 @@ pub fn fabs(x: f64) -> f64 {
     super::generic::fabs(x)
 }
 
+// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
+#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn sanity_check() {
-        assert_eq!(fabs(-1.0), 1.0);
-        assert_eq!(fabs(2.8), 2.8);
+        assert_eq!(fabsf128(-1.0), 1.0);
+        assert_eq!(fabsf128(2.8), 2.8);
     }
 
     /// The spec: https://en.cppreference.com/w/cpp/numeric/math/fabs
     #[test]
     fn spec_tests() {
-        assert!(fabs(f64::NAN).is_nan());
+        assert!(fabsf128(f128::NAN).is_nan());
         for f in [0.0, -0.0].iter().copied() {
-            assert_eq!(fabs(f), 0.0);
+            assert_eq!(fabsf128(f), 0.0);
         }
-        for f in [f64::INFINITY, f64::NEG_INFINITY].iter().copied() {
-            assert_eq!(fabs(f), f64::INFINITY);
+        for f in [f128::INFINITY, f128::NEG_INFINITY].iter().copied() {
+            assert_eq!(fabsf128(f), f128::INFINITY);
         }
     }
 }

--- a/src/math/fabsf16.rs
+++ b/src/math/fabsf16.rs
@@ -1,11 +1,11 @@
-/// Absolute value (magnitude) (f64)
+/// Absolute value (magnitude) (f16)
 ///
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fabs(x: f64) -> f64 {
+pub fn fabsf16(x: f16) -> f16 {
     select_implementation! {
-        name: fabs,
+        name: fabsf,
         use_intrinsic: target_arch = "wasm32",
         args: x,
     }
@@ -13,25 +13,27 @@ pub fn fabs(x: f64) -> f64 {
     super::generic::fabs(x)
 }
 
+// PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520
+#[cfg(not(target_arch = "powerpc64"))]
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn sanity_check() {
-        assert_eq!(fabs(-1.0), 1.0);
-        assert_eq!(fabs(2.8), 2.8);
+        assert_eq!(fabsf16(-1.0), 1.0);
+        assert_eq!(fabsf16(2.8), 2.8);
     }
 
     /// The spec: https://en.cppreference.com/w/cpp/numeric/math/fabs
     #[test]
     fn spec_tests() {
-        assert!(fabs(f64::NAN).is_nan());
+        assert!(fabsf16(f16::NAN).is_nan());
         for f in [0.0, -0.0].iter().copied() {
-            assert_eq!(fabs(f), 0.0);
+            assert_eq!(fabsf16(f), 0.0);
         }
-        for f in [f64::INFINITY, f64::NEG_INFINITY].iter().copied() {
-            assert_eq!(fabs(f), f64::INFINITY);
+        for f in [f16::INFINITY, f16::NEG_INFINITY].iter().copied() {
+            assert_eq!(fabsf16(f), f16::INFINITY);
         }
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -332,6 +332,26 @@ pub use self::tgammaf::tgammaf;
 pub use self::trunc::trunc;
 pub use self::truncf::truncf;
 
+cfg_if! {
+    if #[cfg(f16_enabled)] {
+        mod copysignf16;
+        mod fabsf16;
+
+        pub use self::fabsf16::fabsf16;
+        pub use self::copysignf16::copysignf16;
+    }
+}
+
+cfg_if! {
+    if #[cfg(f128_enabled)] {
+        mod copysignf128;
+        mod fabsf128;
+
+        pub use self::fabsf128::fabsf128;
+        pub use self::copysignf128::copysignf128;
+    }
+}
+
 #[inline]
 fn get_high_word(x: f64) -> u32 {
     (x.to_bits() >> 32) as u32


### PR DESCRIPTION
Requires https://github.com/rust-lang/libm/pull/388, which requires https://github.com/rust-lang/libm/pull/379.