### PR TITLE
Rename generic `abs` to `fabs`

### DIFF
--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -9,7 +9,7 @@ pub fn fabs(x: f64) -> f64 {
         args: x,
     }
 
-    super::generic::abs(x)
+    super::generic::fabs(x)
 }
 
 #[cfg(test)]

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -9,7 +9,7 @@ pub fn fabsf(x: f32) -> f32 {
         args: x,
     }
 
-    super::generic::abs(x)
+    super::generic::fabs(x)
 }
 
 // PowerPC tests are failing on LLVM 13: https://github.com/rust-lang/rust/issues/88520

--- a/src/math/generic/fabs.rs
+++ b/src/math/generic/fabs.rs
@@ -1,6 +1,6 @@
 use super::super::Float;
 
 /// Absolute value.
-pub fn abs<F: Float>(x: F) -> F {
+pub fn fabs<F: Float>(x: F) -> F {
     x.abs()
 }

--- a/src/math/generic/mod.rs
+++ b/src/math/generic/mod.rs
@@ -1,5 +1,5 @@
-mod abs;
 mod copysign;
+mod fabs;
 
-pub use abs::abs;
 pub use copysign::copysign;
+pub use fabs::fabs;


### PR DESCRIPTION
Using the same name as the routines themselves means this will correctly get picked up by the CI job looking for exhaustive tests.