### PR TITLE
Use intrinsics for `abs` and `copysign` when available

### DIFF
--- a/crates/libm-test/src/f8_impl.rs
+++ b/crates/libm-test/src/f8_impl.rs
@@ -70,6 +70,14 @@ impl Float for f8 {
         Self(a)
     }
 
+    fn abs(self) -> Self {
+        libm::generic::fabs(self)
+    }
+
+    fn copysign(self, other: Self) -> Self {
+        libm::generic::copysign(self, other)
+    }
+
     fn normalize(_significand: Self::Int) -> (i32, Self::Int) {
         unimplemented!()
     }

--- a/src/math/generic/copysign.rs
+++ b/src/math/generic/copysign.rs
@@ -5,6 +5,6 @@ pub fn copysign<F: Float>(x: F, y: F) -> F {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= !F::SIGN_MASK;
-    ux |= uy & (F::SIGN_MASK);
+    ux |= uy & F::SIGN_MASK;
     F::from_bits(ux)
 }

--- a/src/math/generic/fabs.rs
+++ b/src/math/generic/fabs.rs
@@ -2,5 +2,6 @@ use super::super::Float;
 
 /// Absolute value.
 pub fn fabs<F: Float>(x: F) -> F {
-    x.abs()
+    let abs_mask = !F::SIGN_MASK;
+    F::from_bits(x.to_bits() & abs_mask)
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -83,11 +83,18 @@ pub mod support;
 #[cfg(not(feature = "unstable-test-support"))]
 mod support;
 
+cfg_if! {
+    if #[cfg(feature = "unstable-test-support")] {
+        pub mod generic;
+    } else {
+        mod generic;
+    }
+}
+
 // Private modules
 mod arch;
 mod expo2;
 mod fenv;
-mod generic;
 mod k_cos;
 mod k_cosf;
 mod k_expo2;


### PR DESCRIPTION
Currently our implementations for `abs` and `copysign` are defined on the trait, and these are then called from `generic`. It would be better to call core's `.abs()` / `.copysign(y)`, but we can't do this in the generic because calling the standalone function could become recursive (`fabsf` becomes `intrinsics::fabsf32`, that may lower to a call to `fabsf`).

Change this so the traits uses the call to `core` if available, falling back to a call to the standalone generic function.

In practice the recursion isn't likely to be a problem since LLVM probably always lowers `abs`/`copysign` to assembly, but this pattern should be more correct for functions that we will add in the future (e.g. `fma`).

This should eventually be followed by a change to call the trait methods rather than `fabs`/`copysign` directly.