### PR TITLE
Add tests against MPFR for `modf` and `modff`

### DIFF
--- a/crates/libm-test/src/mpfloat.rs
+++ b/crates/libm-test/src/mpfloat.rs
@@ -210,6 +210,24 @@ macro_rules! impl_op_for_ty {
                 }
             }
 
+            impl MpOp for crate::op::[<modf $suffix>]::Routine {
+                type MpTy = (MpFloat, MpFloat);
+
+                fn new_mp() -> Self::MpTy {
+                    (new_mpfloat::<Self::FTy>(), new_mpfloat::<Self::FTy>())
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    this.0.assign(input.0);
+                    this.1.assign(&this.0);
+                    let (ord0, ord1) = this.0.trunc_fract_round(&mut this.1, Nearest);
+                    (
+                        prep_retval::<Self::FTy>(&mut this.1, ord0),
+                        prep_retval::<Self::FTy>(&mut this.0, ord1),
+                    )
+                }
+            }
+
             impl MpOp for crate::op::[<pow $suffix>]::Routine {
                 type MpTy = (MpFloat, MpFloat);
 

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -58,8 +58,6 @@ libm_macros::for_each_function! {
         ilogbf,
         ldexp,
         ldexpf,
-        modf,
-        modff,
         remquo,
         remquof,
         scalbn,
@@ -165,7 +163,5 @@ libm_macros::for_each_function! {
         frexpf,
         ilogb,
         ilogbf,
-        modf,
-        modff,
     ],
 }


### PR DESCRIPTION
Rug provides `trunc_fract_round`, which implements `modf`, use it to add a test.