### PR TITLE
Add tests against MPFR for `frexp` and `frexpf`

### DIFF
--- a/crates/libm-test/src/mpfloat.rs
+++ b/crates/libm-test/src/mpfloat.rs
@@ -258,6 +258,25 @@ macro_rules! impl_op_for_ty {
                 }
             }
 
+            impl MpOp for crate::op::[<frexp $suffix>]::Routine {
+                type MpTy = MpFloat;
+
+                fn new_mp() -> Self::MpTy {
+                    new_mpfloat::<Self::FTy>()
+                }
+
+                fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
+                    // Implementation taken from `rug::Float::to_f32_exp`.
+                    this.assign(input.0);
+                    let exp = this.get_exp().unwrap_or(0);
+                    if exp != 0 {
+                        *this >>= exp;
+                    }
+
+                    (prep_retval::<Self::FTy>(this, Ordering::Equal), exp)
+                }
+            }
+
             impl MpOp for crate::op::[<jn $suffix>]::Routine {
                 type MpTy = MpFloat;
 

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -52,8 +52,6 @@ libm_macros::for_each_function! {
     ],
     skip: [
         // FIXME: MPFR tests needed
-        frexp,
-        frexpf,
         ilogb,
         ilogbf,
         ldexp,
@@ -159,8 +157,6 @@ libm_macros::for_each_function! {
         ynf,
 
         // FIXME: MPFR tests needed
-        frexp,
-        frexpf,
         ilogb,
         ilogbf,
     ],


### PR DESCRIPTION
This implementation comes from `rug::Float::to_f32_exp` [1].

MPFR does provide `mpfr_frexp`, but this is not exposed in Rug https://gitlab.com/tspiteri/rug/-/issues/76.

[1]: https://docs.rs/rug/1.26.1/rug/struct.Float.html#method.to_f32_exp