### PR TITLE
Add tests against MPFR for `remquo` and `remquof`

### DIFF
--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -35,7 +35,7 @@ paste = "1.0.15"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.10.0"
-rug = { version = "1.26.1", optional = true, default-features = false, features = ["float", "std"] }
+rug = { version = "1.26.1", optional = true, default-features = false, features = ["float", "integer", "std"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Enable randomness on WASM

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -50,10 +50,6 @@ libm_macros::for_each_function! {
         [jn, jnf, yn, ynf],
     ],
     skip: [
-        // FIXME: MPFR tests needed
-        remquo,
-        remquof,
-
         // FIXME: test needed, see
         // https://github.com/rust-lang/libm/pull/311#discussion_r1818273392
         nextafter,

--- a/crates/libm-test/tests/z_extensive/run.rs
+++ b/crates/libm-test/tests/z_extensive/run.rs
@@ -48,10 +48,6 @@ fn register_all_tests() -> Vec<Trial> {
         callback: mp_extensive_tests,
         extra: [all_tests],
         skip: [
-            // FIXME: MPFR tests needed
-            remquo,
-            remquof,
-
             // FIXME: test needed, see
             // https://github.com/rust-lang/libm/pull/311#discussion_r1818273392
             nextafter,


### PR DESCRIPTION
Rug does not yet expose this function, but it is possible to use the MPFR bindings directly.