### PR TITLE
Rename `unstable-test-support` to `unstable-public-internals`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ unstable = ["unstable-intrinsics", "unstable-float"]
 unstable-intrinsics = []
 
 # Make some internal things public for testing.
-unstable-test-support = []
+unstable-public-internals = []
 
 # Enable the nightly-only `f16` and `f128`.
 unstable-float = []

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -9,14 +9,6 @@ publish = false
 test = false
 bench = false
 
-[features]
-# Duplicated from libm's Cargo.toml
-unstable = []
-unstable-intrinsics = []
-unstable-test-support = []
-checked = []
-force-soft-floats = []
-
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(arch_enabled)",
@@ -24,4 +16,9 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(f128_enabled)",
   "cfg(f16_enabled)",
   "cfg(intrinsics_enabled)",
+  'cfg(feature, values("checked"))',
+  'cfg(feature, values("force-soft-floats"))',
+  'cfg(feature, values("unstable"))',
+  'cfg(feature, values("unstable-intrinsics"))',
+  'cfg(feature, values("unstable-public-internals"))',
 ] }

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -26,7 +26,7 @@ short-benchmarks = []
 [dependencies]
 anyhow = "1.0.90"
 az = { version = "1.2.1", optional = true }
-libm = { path = "../..", features = ["unstable-test-support"] }
+libm = { path = "../..", features = ["unstable-public-internals"] }
 libm-macros = { path = "../libm-macros" }
 musl-math-sys = { path = "../musl-math-sys", optional = true }
 paste = "1.0.15"

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -76,15 +76,15 @@ macro_rules! div {
 
 // `support` may be public for testing
 #[macro_use]
-#[cfg(feature = "unstable-test-support")]
+#[cfg(feature = "unstable-public-internals")]
 pub mod support;
 
 #[macro_use]
-#[cfg(not(feature = "unstable-test-support"))]
+#[cfg(not(feature = "unstable-public-internals"))]
 mod support;
 
 cfg_if! {
-    if #[cfg(feature = "unstable-test-support")] {
+    if #[cfg(feature = "unstable-public-internals")] {
         pub mod generic;
     } else {
         mod generic;


### PR DESCRIPTION
The `support` module that this feature makes public will be useful for implementations in `compiler-builtins`, not only for testing. Give this feature a more accurate name.