### PR TITLE
ci: Only update the github ref for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,6 +198,7 @@ jobs:
           fetch-depth: 100
       - name: Fetch pull request ref
         run: git fetch origin "$GITHUB_REF:$GITHUB_REF"
+        if: github.event_name == 'pull_request'
       - run: python3 ci/calculate-exhaustive-matrix.py >> "$GITHUB_OUTPUT"
         id: script
 


### PR DESCRIPTION
On master, this fetch fails with:

    fatal: refusing to fetch into branch 'refs/heads/master' checked out at '/home/runner/work/libm/libm'

Just skip the command when this shouldn't be needed.