### PR TITLE
Switch from using `unstable-intrinsics` to `intrinsics_enabled`

### DIFF
--- a/src/math/arch/intrinsics.rs
+++ b/src/math/arch/intrinsics.rs
@@ -12,13 +12,11 @@ pub fn ceilf(x: f32) -> f32 {
 }
 
 pub fn fabs(x: f64) -> f64 {
-    // SAFETY: safe intrinsic with no preconditions
-    unsafe { core::intrinsics::fabsf64(x) }
+    x.abs()
 }
 
 pub fn fabsf(x: f32) -> f32 {
-    // SAFETY: safe intrinsic with no preconditions
-    unsafe { core::intrinsics::fabsf32(x) }
+    x.abs()
 }
 
 pub fn floor(x: f64) -> f64 {

--- a/src/math/support/float_traits.rs
+++ b/src/math/support/float_traits.rs
@@ -200,7 +200,7 @@ macro_rules! float_impl {
             fn abs(self) -> Self {
                 cfg_if! {
                     // FIXME(msrv): `abs` is available in `core` starting with 1.85.
-                    if #[cfg(feature = "unstable-intrinsics")] {
+                    if #[cfg(intrinsics_enabled)] {
                         self.abs()
                     } else {
                         super::super::generic::fabs(self)
@@ -210,7 +210,7 @@ macro_rules! float_impl {
             fn copysign(self, other: Self) -> Self {
                 cfg_if! {
                     // FIXME(msrv): `copysign` is available in `core` starting with 1.85.
-                    if #[cfg(feature = "unstable-intrinsics")] {
+                    if #[cfg(intrinsics_enabled)] {
                         self.copysign(other)
                     } else {
                         super::super::generic::copysign(self, other)


### PR DESCRIPTION
Unlike `unstable-intrinsics`, `intrinsics_enabled` gets disabled with `force-soft-floats` which is what we want here.