### PR TITLE
Don't use intrinsics abs for `f16` and `f128` on wasm32

### DIFF
--- a/src/math/fabsf128.rs
+++ b/src/math/fabsf128.rs
@@ -4,12 +4,6 @@
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fabsf128(x: f128) -> f128 {
-    select_implementation! {
-        name: fabsf,
-        use_intrinsic: target_arch = "wasm32",
-        args: x,
-    }
-
     super::generic::fabs(x)
 }
 

--- a/src/math/fabsf16.rs
+++ b/src/math/fabsf16.rs
@@ -4,12 +4,6 @@
 /// by direct manipulation of the bit representation of `x`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fabsf16(x: f16) -> f16 {
-    select_implementation! {
-        name: fabsf,
-        use_intrinsic: target_arch = "wasm32",
-        args: x,
-    }
-
     super::generic::fabs(x)
 }
 


### PR DESCRIPTION
This configuration was duplicated from `fabs` and `fabsf`, but wasm is unlikely to have an intrinsic lowering for these float types. So, just always use the generic.