### PR TITLE
Replace "intrinsic" config with "arch" config

### DIFF
--- a/etc/function-definitions.json
+++ b/etc/function-definitions.json
@@ -108,14 +108,14 @@
         "sources": [
             "src/libm_helper.rs",
             "src/math/arch/i586.rs",
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/ceil.rs"
         ],
         "type": "f64"
     },
     "ceilf": {
         "sources": [
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/ceilf.rs"
         ],
         "type": "f32"
@@ -258,7 +258,7 @@
     "fabs": {
         "sources": [
             "src/libm_helper.rs",
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/fabs.rs",
             "src/math/generic/fabs.rs"
         ],
@@ -266,7 +266,7 @@
     },
     "fabsf": {
         "sources": [
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/fabsf.rs",
             "src/math/generic/fabs.rs"
         ],
@@ -303,14 +303,14 @@
         "sources": [
             "src/libm_helper.rs",
             "src/math/arch/i586.rs",
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/floor.rs"
         ],
         "type": "f64"
     },
     "floorf": {
         "sources": [
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/floorf.rs"
         ],
         "type": "f32"
@@ -683,7 +683,7 @@
         "sources": [
             "src/libm_helper.rs",
             "src/math/arch/i686.rs",
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/sqrt.rs"
         ],
         "type": "f64"
@@ -691,7 +691,7 @@
     "sqrtf": {
         "sources": [
             "src/math/arch/i686.rs",
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/sqrtf.rs"
         ],
         "type": "f32"
@@ -738,14 +738,14 @@
     "trunc": {
         "sources": [
             "src/libm_helper.rs",
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/trunc.rs"
         ],
         "type": "f64"
     },
     "truncf": {
         "sources": [
-            "src/math/arch/intrinsics.rs",
+            "src/math/arch/wasm32.rs",
             "src/math/truncf.rs"
         ],
         "type": "f32"

--- a/src/math/arch/mod.rs
+++ b/src/math/arch/mod.rs
@@ -5,14 +5,14 @@
 //! is used when calling the function directly. This helps anyone who uses `libm` directly, as
 //! well as improving things when these routines are called as part of other implementations.
 
-#[cfg(intrinsics_enabled)]
-pub mod intrinsics;
-
 // Most implementations should be defined here, to ensure they are not made available when
 // soft floats are required.
 #[cfg(arch_enabled)]
 cfg_if! {
-    if #[cfg(target_feature = "sse2")] {
+    if #[cfg(all(target_arch = "wasm32", intrinsics_enabled))] {
+        mod wasm32;
+        pub use wasm32::{ceil, ceilf, fabs, fabsf, floor, floorf, sqrt, sqrtf, trunc, truncf};
+    } else if #[cfg(target_feature = "sse2")] {
         mod i686;
         pub use i686::{sqrt, sqrtf};
     }

--- a/src/math/arch/wasm32.rs
+++ b/src/math/arch/wasm32.rs
@@ -1,5 +1,7 @@
-// Config is needed for times when this module is available but we don't call everything
-#![allow(dead_code)]
+//! Wasm asm is not stable; just use intrinsics for operations that have asm routine equivalents.
+//!
+//! Note that we need to be absolutely certain that everything here lowers to assembly operations,
+//! otherwise libcalls will be recursive.
 
 pub fn ceil(x: f64) -> f64 {
     // SAFETY: safe intrinsic with no preconditions

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -10,8 +10,8 @@ const TOINT: f64 = 1. / f64::EPSILON;
 pub fn ceil(x: f64) -> f64 {
     select_implementation! {
         name: ceil,
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         use_arch_required: all(target_arch = "x86", not(target_feature = "sse2")),
-        use_intrinsic: target_arch = "wasm32",
         args: x,
     }
 

--- a/src/math/ceilf.rs
+++ b/src/math/ceilf.rs
@@ -7,7 +7,7 @@ use core::f32;
 pub fn ceilf(x: f32) -> f32 {
     select_implementation! {
         name: ceilf,
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         args: x,
     }
 

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -6,7 +6,7 @@
 pub fn fabs(x: f64) -> f64 {
     select_implementation! {
         name: fabs,
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         args: x,
     }
 

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -6,7 +6,7 @@
 pub fn fabsf(x: f32) -> f32 {
     select_implementation! {
         name: fabsf,
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         args: x,
     }
 

--- a/src/math/floor.rs
+++ b/src/math/floor.rs
@@ -10,8 +10,8 @@ const TOINT: f64 = 1. / f64::EPSILON;
 pub fn floor(x: f64) -> f64 {
     select_implementation! {
         name: floor,
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         use_arch_required: all(target_arch = "x86", not(target_feature = "sse2")),
-        use_intrinsic: target_arch = "wasm32",
         args: x,
     }
 

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -7,7 +7,7 @@ use core::f32;
 pub fn floorf(x: f32) -> f32 {
     select_implementation! {
         name: floorf,
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         args: x,
     }
 

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -83,8 +83,10 @@ use core::f64;
 pub fn sqrt(x: f64) -> f64 {
     select_implementation! {
         name: sqrt,
-        use_arch: target_feature = "sse2",
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: any(
+            all(target_arch = "wasm32", intrinsics_enabled),
+            target_feature = "sse2"
+        ),
         args: x,
     }
 

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -18,8 +18,10 @@
 pub fn sqrtf(x: f32) -> f32 {
     select_implementation! {
         name: sqrtf,
-        use_arch: target_feature = "sse2",
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: any(
+            all(target_arch = "wasm32", intrinsics_enabled),
+            target_feature = "sse2"
+        ),
         args: x,
     }
 

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -7,7 +7,7 @@ use core::f64;
 pub fn trunc(x: f64) -> f64 {
     select_implementation! {
         name: trunc,
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         args: x,
     }
 

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -7,7 +7,7 @@ use core::f32;
 pub fn truncf(x: f32) -> f32 {
     select_implementation! {
         name: truncf,
-        use_intrinsic: target_arch = "wasm32",
+        use_arch: all(target_arch = "wasm32", intrinsics_enabled),
         args: x,
     }
 


### PR DESCRIPTION
WASM is the only architecture we use `intrinsics::` for. We probably don't want to do this for any other architectures since it is better to use assembly, or work toward getting the functions available in `core`.

To more accurately reflect the relationship between arch and intrinsics, make wasm32 an `arch` module and call the intrinsics from there.