### PR TITLE
Increase the allowed ULP for `tgammaf`

### DIFF
--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -44,7 +44,6 @@ pub fn default_ulp(ctx: &CheckCtx) -> u32 {
 
         // Operations that aren't required to be exact, but our implementations are.
         Bn::Cbrt if ctx.fn_ident != Id::Cbrt => 0,
-        Bn::Tgamma if ctx.fn_ident != Id::Tgamma => 0,
 
         // Bessel functions have large inaccuracies.
         Bn::J0 | Bn::J1 | Bn::Y0 | Bn::Y1 | Bn::Jn | Bn::Yn => 8_000_000,
@@ -78,6 +77,8 @@ pub fn default_ulp(ctx: &CheckCtx) -> u32 {
         Bn::Sinh => 2,
         Bn::Tan => 1,
         Bn::Tanh => 2,
+        // tgammaf has higher accuracy than tgamma.
+        Bn::Tgamma if ctx.fn_ident != Id::Tgamma => 1,
         Bn::Tgamma => 20,
     };
 


### PR DESCRIPTION
Extensive tests report that the precision isn't actually 0:

    ---- mp_extensive_tgammaf ----

        input:    (-0.00063536887,) (0xba268ee2,)
        expected: -1574.4668             0xc4c4cef0
        actual:   -1574.4667             0xc4c4ceef

    Caused by:
        ulp 1 > 0

Update ULP to reflect this. After this change, `tgammaf` extensive tests pass.