### PR TITLE
Reorder tests in `run.sh`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -75,16 +75,14 @@ if [ "${BUILD_ONLY:-}" = "1" ]; then
 else
     cmd="cargo test --all --target $target $extra_flags"
 
-    # Test without intrinsics
+    # Test once without intrinsics, once with intrinsics enabled
     $cmd
-    $cmd --release
-
-    # Test with intrinsic use
     $cmd --features unstable-intrinsics
+    $cmd --features unstable-intrinsics --benches
+    
+    # Test the same in release mode, which also increases coverage.
+    $cmd --release
     $cmd --release --features unstable-intrinsics
-
-    # Make sure benchmarks have correct results
-    $cmd --benches
-    $cmd --benches --release
+    $cmd --release --features unstable-intrinsics --benches
 fi
 


### PR DESCRIPTION
I do not believe Cargo separately caches crates with different sets of features enabled. So, ensuring that tests run with `unstable-intrinsics` are always grouped should slightly reduce runtime.

As an added benefit, all the debug mode tests run first so initial feedback is available faster.