### PR TITLE
Add a `release-checked` profile with debug and overflow assertions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,7 +238,8 @@ jobs:
 
           LIBM_EXTENSIVE_TESTS="$CHANGED" cargo t \
             --features test-multiprecision,unstable \
-            --release -- extensive
+            --profile release-checked \
+            -- extensive
       - name: Print test logs if available
         run: if [ -f "target/test-log.txt" ]; then cat target/test-log.txt; fi
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,10 @@ no-panic = "0.1.30"
 # This is needed for no-panic to correctly detect the lack of panics
 [profile.release]
 lto = "fat"
+
+# Release mode with debug assertions
+[profile.release-checked]
+inherits = "release"
+debug-assertions = true
+lto = "fat"
+overflow-checks = true

--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,12 @@ fn main() {
     #[allow(unexpected_cfgs)]
     if !cfg!(feature = "checked") {
         let lvl = env::var("OPT_LEVEL").unwrap();
-        if lvl != "0" {
+        if lvl != "0" && !cfg!(debug_assertions) {
             println!("cargo:rustc-cfg=assert_no_panic");
+        } else if env::var("ENSURE_NO_PANIC").is_ok() {
+            // Give us a defensive way of ensureing that no-panic is checked  when we
+            // expect it to be.
+            panic!("`assert_no_panic `was not enabled");
         }
     }
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -81,8 +81,10 @@ else
     $cmd --features unstable-intrinsics --benches
     
     # Test the same in release mode, which also increases coverage.
-    $cmd --release
-    $cmd --release --features unstable-intrinsics
-    $cmd --release --features unstable-intrinsics --benches
+    $cmd --profile release-checked 
+    $cmd --profile release-checked --features unstable-intrinsics
+    $cmd --profile release-checked --features unstable-intrinsics --benches
+
+    ENSURE_NO_PANIC=1 cargo build --target "$target" --release
 fi
 


### PR DESCRIPTION
A failing debug assertion or overflow without correctly wrapping or saturating is a bug, but the `debug` profile that has these enabled does not run enough test cases to hit edge cases that may trigger these. Add a new `release-checked` profile that enables debug assertions and overflow checks. This seems to only extend per-function test time by a few seconds (or around a minute on longer extensive tests), so enable this as the default on CI.

In order to ensure `no_panic` still gets checked, add a build-only step to CI.