### PR TITLE
Add `biteq` and `exp_unbiased` to `Float`

### DIFF
--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -54,10 +54,14 @@ pub trait Int:
     + ops::BitXor<Output = Self>
     + ops::BitAnd<Output = Self>
     + cmp::Ord
-    + CastInto<usize>
-    + CastInto<i32>
     + CastFrom<i32>
+    + CastFrom<u32>
     + CastFrom<u8>
+    + CastFrom<usize>
+    + CastInto<i32>
+    + CastInto<u32>
+    + CastInto<u8>
+    + CastInto<usize>
 {
     fn signed(self) -> OtherSign<Self::Unsigned>;
     fn unsigned(self) -> Self::Unsigned;

--- a/src/math/support/macros.rs
+++ b/src/math/support/macros.rs
@@ -106,3 +106,23 @@ macro_rules! hf64 {
         X
     }};
 }
+
+/// Assert `F::biteq` with better messages.
+#[cfg(test)]
+macro_rules! assert_biteq {
+    ($left:expr, $right:expr, $($arg:tt)*) => {{
+        let bits = ($left.to_bits() * 0).leading_zeros(); // hack to get the width from the value
+        assert!(
+            $left.biteq($right),
+            "\nl: {l:?} ({lb:#0width$x})\nr: {r:?} ({rb:#0width$x})",
+            l = $left,
+            lb = $left.to_bits(),
+            r = $right,
+            rb = $right.to_bits(),
+            width = ((bits / 4) + 2) as usize
+        );
+    }};
+    ($left:expr, $right:expr $(,)?) => {
+        assert_biteq!($left, $right,)
+    };
+}


### PR DESCRIPTION
These are two convenience methods. Additionally, add tests for the trait methods, and an `assert_biteq!` macro to check and print the output.