### PR TITLE
Always use the same seed for benchmarking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,11 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Download musl source
       run: ./ci/download-musl.sh
-    - run: cargo bench --all --features libm-test/short-benchmarks,libm-test/build-musl
+    - run: |
+        # Always use the same seed for benchmarks. Ideally we should switch to a
+        # non-random generator.
+        export LIBM_SEED=benchesbenchesbenchesbencheswoo!
+        cargo bench --all --features libm-test/short-benchmarks,libm-test/build-musl
 
   msrv:
     name: Check MSRV


### PR DESCRIPTION
It would be preferable to switch to a different generator, or at least set the seed within the benchmark, but this is the most straightforward way to make things simple.