### PR TITLE
Add a new precision adjustment for i586 `rint` and `exp2f`

### DIFF
--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -211,6 +211,15 @@ impl MaybeOverride<(f32,)> for SpecialCase {
             return XFAIL;
         }
 
+        if cfg!(x86_no_sse)
+            && ctx.base_name == BaseName::Exp2
+            && !expected.is_infinite()
+            && actual.is_infinite()
+        {
+            // We return infinity when there is a representable value. Test input: 127.97238
+            return XFAIL;
+        }
+
         maybe_check_nan_bits(actual, expected, ctx)
     }
 

--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -114,7 +114,6 @@ pub fn default_ulp(ctx: &CheckCtx) -> u32 {
             Id::Exp10 | Id::Exp10f => ulp = 1_000_000,
             Id::Exp2 | Id::Exp2f => ulp = 10_000_000,
             Id::Log1p | Id::Log1pf => ulp = 2,
-            Id::Rint => ulp = 100_000,
             Id::Round => ulp = 1,
             Id::Tan => ulp = 2,
             _ => (),
@@ -259,6 +258,15 @@ impl MaybeOverride<(f64,)> for SpecialCase {
                 // musl returns -0.0, we return +0.0
                 return XFAIL;
             }
+        }
+
+        if cfg!(x86_no_sse)
+            && ctx.base_name == BaseName::Rint
+            && (expected - actual).abs() <= F::ONE
+            && (expected - actual).abs() > F::ZERO
+        {
+            // Our rounding mode is incorrect.
+            return XFAIL;
         }
 
         if ctx.base_name == BaseName::Acosh && input.0 < 1.0 {


### PR DESCRIPTION
`rint` had a couple recent failures from the random tests:

    ---- mp_random_rint stdout ----
    Random Mpfr rint arg 1/1: 10000 iterations (10000 total) using `LIBM_SEED=Fl1f69DaJnwkHN2FeuCXaBFRvJYsPvEY`

    thread 'mp_random_rint' panicked at crates/libm-test/tests/multiprecision.rs:41:49:
    called `Result::unwrap()` on an `Err` value:
        input:    (-849751480.5001163,) (0xc1c95316dc4003d0,)
        expected: -849751481.0           0xc1c95316dc800000
        actual:   -849751480.0           0xc1c95316dc000000

    Caused by:
        ulp 8388608 > 100000

And:

    ---- mp_random_rint stdout ----
    Random Mpfr rint arg 1/1: 10000 iterations (10000 total) using `LIBM_SEED=XN7VCGhX3Wu6Mzn8COvJPITyZlGP7gN7`

    thread 'mp_random_rint' panicked at crates/libm-test/tests/multiprecision.rs:41:49:
    called `Result::unwrap()` on an `Err` value:
        input:    (-12493089.499809155,) (0xc167d4242ffe6fc5,)
        expected: -12493089.0            0xc167d42420000000
        actual:   -12493090.0            0xc167d42440000000

    Caused by:
        ulp 536870912 > 100000

It seems we just implement an incorrect rounding mode. Replace the existing `rint` override with an xfail if the difference is 0.0 <= ε <= 1.0.

---

There was a recent failure from the random tests:

     ---- mp_random_exp2f stdout ----
    Random Mpfr exp2f arg 1/1: 10000 iterations (10000 total) using `LIBM_SEED=fqgMuzs6eqH1VZSEmQpLnThnaIyRUOWe`

    thread 'mp_random_exp2f' panicked at crates/libm-test/tests/multiprecision.rs:41:49:
    called `Result::unwrap()` on an `Err` value:
        input:    (127.97238,) (0x42fff1dc,)
        expected: 3.3383009e38           0x7f7b2556
        actual:   inf                    0x7f800000

    Caused by:
        mismatched infinities

Add an xfail for mismatched infinities on i586.