### PR TITLE
Rename the `test-multiprecision` feature to `build-mpfr`, enable by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,10 +131,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Download musl source
       run: ./ci/download-musl.sh
-    - run: |
-        cargo clippy --all \
-          --features libm-test/build-musl,libm-test/build-mpfr \
-          --all-targets
+    - run: cargo clippy --all --all-features --all-targets
 
   builtins:
     name: Check use with compiler-builtins

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
       run: ./ci/download-musl.sh
     - run: |
         cargo clippy --all \
-          --features libm-test/build-musl,libm-test/test-multiprecision \
+          --features libm-test/build-musl,libm-test/build-mpfr \
           --all-targets
 
   builtins:
@@ -241,7 +241,7 @@ jobs:
           fi
 
           LIBM_EXTENSIVE_TESTS="$CHANGED" cargo t \
-            --features test-multiprecision,unstable \
+            --features build-mpfr,unstable \
             --profile release-checked \
             -- extensive
       - name: Print test logs if available

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ If you'd like to run tests with randomized inputs that get compared against
 infinite-precision results, run:
 
 ```sh
-cargo test --features libm-test/test-multiprecision,libm-test/build-musl --release
+cargo test --features libm-test/build-mpfr,libm-test/build-musl --release
 ```
 
 The multiprecision tests use the [`rug`] crate for bindings to MPFR. MPFR can

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,15 +62,12 @@ Check [PR #65] for an example.
 Normal tests can be executed with:
 
 ```sh
-cargo test
+# `--release` ables more test cases
+cargo test --release
 ```
 
-If you'd like to run tests with randomized inputs that get compared against
-infinite-precision results, run:
-
-```sh
-cargo test --features libm-test/build-mpfr,libm-test/build-musl --release
-```
+If you are on a system that cannot build musl or MPFR, passing
+`--no-default-features` will run some limited tests.
 
 The multiprecision tests use the [`rug`] crate for bindings to MPFR. MPFR can
 be difficult to build on non-Unix systems, refer to [`gmp_mpfr_sys`] for help.

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -44,11 +44,11 @@ case "$target" in
     # Targets that aren't cross compiled work fine
     # FIXME(ci): we should be able to enable aarch64 Linux here once GHA
     # support rolls out.
-    x86_64*) extra_flags="$extra_flags --features libm-test/test-multiprecision" ;;
-    i686*) extra_flags="$extra_flags --features libm-test/test-multiprecision" ;;
-    i586*) extra_flags="$extra_flags --features libm-test/test-multiprecision --features gmp-mpfr-sys/force-cross" ;;
+    x86_64*) extra_flags="$extra_flags --features libm-test/build-mpfr" ;;
+    i686*) extra_flags="$extra_flags --features libm-test/build-mpfr" ;;
+    i586*) extra_flags="$extra_flags --features libm-test/build-mpfr --features gmp-mpfr-sys/force-cross" ;;
     # Apple aarch64 is native
-    aarch64*apple*) extra_flags="$extra_flags --features libm-test/test-multiprecision" ;;
+    aarch64*apple*) extra_flags="$extra_flags --features libm-test/build-mpfr" ;;
 esac
 
 # FIXME: `STATUS_DLL_NOT_FOUND` testing macros on CI.

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -12,7 +12,7 @@ unstable-float = ["libm/unstable-float", "rug?/nightly-float"]
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
-test-multiprecision = ["dep:az", "dep:rug", "dep:gmp-mpfr-sys"]
+build-mpfr = ["dep:az", "dep:rug", "dep:gmp-mpfr-sys"]
 
 # Build our own musl for testing and benchmarks
 build-musl = ["dep:musl-math-sys"]

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["unstable-float"]
+default = ["build-mpfr", "build-musl", "unstable-float"]
 
 # Propagated from libm because this affects which functions we test.
 unstable-float = ["libm/unstable-float", "rug?/nightly-float"]

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod domain;
 mod f8_impl;
 pub mod gen;
-#[cfg(feature = "test-multiprecision")]
+#[cfg(feature = "build-mpfr")]
 pub mod mpfloat;
 mod num;
 pub mod op;

--- a/crates/libm-test/src/run_cfg.rs
+++ b/crates/libm-test/src/run_cfg.rs
@@ -126,7 +126,7 @@ impl TestEnv {
         let id = ctx.fn_ident;
         let op = id.math_op();
 
-        let will_run_mp = cfg!(feature = "test-multiprecision");
+        let will_run_mp = cfg!(feature = "build-mpfr");
 
         // Tests are pretty slow on non-64-bit targets, x86 MacOS, and targets that run in QEMU. Start
         // with a reduced number on these platforms.

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -1,6 +1,6 @@
 //! Test with "infinite precision"
 
-#![cfg(feature = "test-multiprecision")]
+#![cfg(feature = "build-mpfr")]
 
 use libm_test::domain::HasDomain;
 use libm_test::gen::random::RandomInput;

--- a/crates/libm-test/tests/z_extensive/main.rs
+++ b/crates/libm-test/tests/z_extensive/main.rs
@@ -1,14 +1,14 @@
 //! `main` is just a wrapper to handle configuration.
 
-#[cfg(not(feature = "test-multiprecision"))]
+#[cfg(not(feature = "build-mpfr"))]
 fn main() {
     eprintln!("multiprecision not enabled; skipping extensive tests");
 }
 
-#[cfg(feature = "test-multiprecision")]
+#[cfg(feature = "build-mpfr")]
 mod run;
 
-#[cfg(feature = "test-multiprecision")]
+#[cfg(feature = "build-mpfr")]
 fn main() {
     run::run();
 }


### PR DESCRIPTION
Currently the features that control what we test against are `build-musl` and `test-multiprecision`. I didn't name them very consistently and there isn't really any reason for that.

Rename `test-multiprecision` to `build-mpfr` to better reflect what it actually does and to be more consistent with `build-musl`.

---

Most users who are developing this crate are likely running on a Unix system, since there isn't much to test against otherwise. For convenience, enable the features required to run these tests by default.

This is for the internal test crate, no user-facing changes.