### PR TITLE
Use cargo-nextest for running tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 env:
+  CARGO_TERM_COLOR: always
   CARGO_TERM_VERBOSE: true
   RUSTDOCFLAGS: -Dwarnings
   RUSTFLAGS: -Dwarnings
@@ -88,6 +89,7 @@ jobs:
         rustup default "$channel"
         rustup target add "${{ matrix.target }}"
         rustup component add clippy llvm-tools-preview
+    - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-plz:
     name: Release-plz
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/ci/download-musl.sh
+++ b/ci/download-musl.sh
@@ -7,7 +7,7 @@ fname=musl-1.2.5.tar.gz
 sha=a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4
 
 mkdir musl
-curl "https://musl.libc.org/releases/$fname" -O
+curl -L "https://musl.libc.org/releases/$fname" -O
 
 case "$(uname -s)" in
     MINGW*)

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -24,12 +24,14 @@ run() {
     # will be owned by root
     mkdir -p target
 
-    docker build -t "$target" "ci/docker/$target"
+    set_env="HOME=/tmp PATH=\$PATH:/rust/bin:/cargo/bin"
+    docker build -t "libm-$target" "ci/docker/$target"
     docker run \
         --rm \
         --user "$(id -u):$(id -g)" \
         -e CI \
         -e RUSTFLAGS \
+        -e CARGO_TERM_COLOR \
         -e CARGO_HOME=/cargo \
         -e CARGO_TARGET_DIR=/target \
         -e "EMULATED=$emulated" \
@@ -39,8 +41,8 @@ run() {
         -v "$(rustc --print sysroot):/rust:ro" \
         --init \
         -w /checkout \
-        "$target" \
-        sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh $target"
+        "libm-$target" \
+        sh -c "$set_env exec ci/run.sh $target"
 }
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
The test suite for this repo has quite a lot of tests, and it is difficult to tell which contribute the most to the long CI runtime. libtest does have an unstable flag to report test times, but that is inconvenient to use because it needs to be passed only to libtest binaries.

Switch to cargo-nextest [1] which provides time reporting and, overall, a better test UI. It may also improve test runtime, though this seems unlikely since we have larger test binaries with many small tests (nextest benefits the most when there are larger binaries that can be run in parallel).

For anyone running locally without, `run.sh` should still fall back to `cargo test` if `cargo-nextest` is not available.

This diff includes some cleanup and consistency changes to other CI-related files.

[1]: https://nexte.st