### PR TITLE
Simplify and optimize fdim

### DIFF
--- a/src/math/generic/fdim.rs
+++ b/src/math/generic/fdim.rs
@@ -1,13 +1,9 @@
 use super::super::Float;
 
 pub fn fdim<F: Float>(x: F, y: F) -> F {
-    if x.is_nan() {
-        x
-    } else if y.is_nan() {
-        y
-    } else if x > y {
-        x - y
-    } else {
+    if x <= y {
         F::ZERO
+    } else {
+        x - y
     }
 }

--- a/src/math/generic/fdim.rs
+++ b/src/math/generic/fdim.rs
@@ -1,9 +1,5 @@
 use super::super::Float;
 
 pub fn fdim<F: Float>(x: F, y: F) -> F {
-    if x <= y {
-        F::ZERO
-    } else {
-        x - y
-    }
+    if x <= y { F::ZERO } else { x - y }
 }


### PR DESCRIPTION
The cases with `NaN` arguments can be handled by the same `x - y` expression, and this generates much better code: 
https://godbolt.org/z/r6sa6o5ov