### PR TITLE
Switch to the arm-linux runner and enable MPFR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
         - target: aarch64-apple-darwin
           os: macos-15
         - target: aarch64-unknown-linux-gnu
-          os: ubuntu-24.04
+          os: ubuntu-24.04-arm
         - target: aarch64-pc-windows-msvc
           os: windows-2025
           build_only: 1 # Can't run on x86 hosts

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -49,14 +49,12 @@ case "$target" in
     *windows-msvc*) ;;
     # FIXME: MinGW should be able to build MPFR, but setup in CI is nontrivial.
     *windows-gnu*) ;;
-    # Targets that aren't cross compiled work fine
-    # FIXME(ci): we should be able to enable aarch64 Linux here once GHA
-    # support rolls out.
-    x86_64*) flags="$flags --features libm-test/build-mpfr" ;;
-    i686*) flags="$flags --features libm-test/build-mpfr" ;;
-    i586*) flags="$flags --features libm-test/build-mpfr --features gmp-mpfr-sys/force-cross" ;;
-    # Apple aarch64 is native
+    # Targets that aren't cross compiled in CI work fine
     aarch64*apple*) flags="$flags --features libm-test/build-mpfr" ;;
+    aarch64*linux*) flags="$flags --features libm-test/build-mpfr" ;;
+    i586*) flags="$flags --features libm-test/build-mpfr --features gmp-mpfr-sys/force-cross" ;;
+    i686*) flags="$flags --features libm-test/build-mpfr" ;;
+    x86_64*) flags="$flags --features libm-test/build-mpfr" ;;
 esac
 
 # FIXME: `STATUS_DLL_NOT_FOUND` testing macros on CI.


### PR DESCRIPTION
The free arm64 Linux runners are now available [1]. Switch to using this image in CI, and enable tests against MPFR since this is now a native platform.

[1]: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/