### PR TITLE
Add a retry to the musl download

### DIFF
--- a/ci/download-musl.sh
+++ b/ci/download-musl.sh
@@ -7,7 +7,7 @@ fname=musl-1.2.5.tar.gz
 sha=a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4
 
 mkdir musl
-curl -L "https://musl.libc.org/releases/$fname" -O
+curl -L "https://musl.libc.org/releases/$fname" -O --retry 5
 
 case "$(uname -s)" in
     MINGW*)


### PR DESCRIPTION
This download has occasionally been failing in CI recently. Add a retry so this is less likely to cause the workflow to fail.