### PR TITLE
Add `hf16!` and `hf128!`

### DIFF
--- a/src/math/support/macros.rs
+++ b/src/math/support/macros.rs
@@ -87,6 +87,17 @@ macro_rules! select_implementation {
     (@cfg $provided:meta; $ex:expr) => { #[cfg($provided)] $ex };
 }
 
+/// Construct a 16-bit float from hex float representation (C-style), guaranteed to
+/// evaluate at compile time.
+#[cfg(f16_enabled)]
+#[allow(unused_macros)]
+macro_rules! hf16 {
+    ($s:literal) => {{
+        const X: f16 = $crate::math::support::hf16($s);
+        X
+    }};
+}
+
 /// Construct a 32-bit float from hex float representation (C-style), guaranteed to
 /// evaluate at compile time.
 #[allow(unused_macros)]
@@ -103,6 +114,17 @@ macro_rules! hf32 {
 macro_rules! hf64 {
     ($s:literal) => {{
         const X: f64 = $crate::math::support::hf64($s);
+        X
+    }};
+}
+
+/// Construct a 128-bit float from hex float representation (C-style), guaranteed to
+/// evaluate at compile time.
+#[cfg(f128_enabled)]
+#[allow(unused_macros)]
+macro_rules! hf128 {
+    ($s:literal) => {{
+        const X: f128 = $crate::math::support::hf128($s);
         X
     }};
 }

--- a/src/math/support/mod.rs
+++ b/src/math/support/mod.rs
@@ -8,6 +8,10 @@ mod int_traits;
 #[allow(unused_imports)]
 pub use float_traits::{Float, IntTy};
 pub(crate) use float_traits::{f32_from_bits, f64_from_bits};
+#[cfg(f16_enabled)]
+pub use hex_float::hf16;
+#[cfg(f128_enabled)]
+pub use hex_float::hf128;
 #[allow(unused_imports)]
 pub use hex_float::{hf32, hf64};
 pub use int_traits::{CastFrom, CastInto, DInt, HInt, Int, MinInt};


### PR DESCRIPTION
Expand the existing hex float functions and macros with versions that work with `f16` and `f128`.

Cc @quaternic since this is your code