### PR TITLE
Test with the unreleased version of rug

### DIFF
--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -39,7 +39,7 @@ paste = "1.0.15"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.10.0"
-rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "2d96613fc1d84882b8651e86232fbb54ebe7c4c3", optional = true, default-features = false, features = ["float", "integer", "std"] }
+rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "96d26fff459cc6be3f6c505a5bc55d14b9ac0222", optional = true, default-features = false, features = ["float", "integer", "std"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Enable randomness on WASM

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -39,7 +39,7 @@ paste = "1.0.15"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.10.0"
-rug = { version = "1.26.1", optional = true, default-features = false, features = ["float", "integer", "std"] }
+rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "3d44b8d87d38c4a138fc74653a44ca9c518caac4", optional = true, default-features = false, features = ["float", "integer", "std"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Enable randomness on WASM

--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -39,7 +39,7 @@ paste = "1.0.15"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rayon = "1.10.0"
-rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "3d44b8d87d38c4a138fc74653a44ca9c518caac4", optional = true, default-features = false, features = ["float", "integer", "std"] }
+rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "2d96613fc1d84882b8651e86232fbb54ebe7c4c3", optional = true, default-features = false, features = ["float", "integer", "std"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Enable randomness on WASM

--- a/crates/libm-test/src/mpfloat.rs
+++ b/crates/libm-test/src/mpfloat.rs
@@ -4,13 +4,10 @@
 //! a struct named `Operation` that implements [`MpOp`].
 
 use std::cmp::Ordering;
-use std::ffi::{c_int, c_long};
 
 use az::Az;
-use gmp_mpfr_sys::mpfr::rnd_t;
 use rug::Assign;
 pub use rug::Float as MpFloat;
-use rug::float::Round;
 use rug::float::Round::Nearest;
 use rug::ops::{PowAssignRound, RemAssignRound};
 
@@ -318,13 +315,8 @@ macro_rules! impl_op_for_ty {
                 }
 
                 fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
-                    // Implementation taken from `rug::Float::to_f32_exp`.
                     this.assign(input.0);
-                    let exp = this.get_exp().unwrap_or(0);
-                    if exp != 0 {
-                        *this >>= exp;
-                    }
-
+                    let exp = this.frexp_mut();
                     (prep_retval::<Self::FTy>(this, Ordering::Equal), exp)
                 }
             }
@@ -414,28 +406,20 @@ macro_rules! impl_op_for_ty {
             }
 
             impl MpOp for crate::op::[<remquo $suffix>]::Routine {
-                type MpTy = (MpFloat, MpFloat, MpFloat);
+                type MpTy = (MpFloat, MpFloat);
 
                 fn new_mp() -> Self::MpTy {
                     (
                         new_mpfloat::<Self::FTy>(),
                         new_mpfloat::<Self::FTy>(),
-                        new_mpfloat::<Self::FTy>()
                     )
                 }
 
                 fn run(this: &mut Self::MpTy, input: Self::RustArgs) -> Self::RustRet {
                     this.0.assign(input.0);
                     this.1.assign(input.1);
-                    let (ord, ql) = mpfr_remquo(&mut this.2, &this.0, &this.1, Nearest);
-
-                    // `remquo` integer results are sign-magnitude representation. Transfer the
-                    // sign bit from the long result to the int result.
-                    let clear = !(1 << (c_int::BITS - 1));
-                    let sign = ((ql >> (c_long::BITS - 1)) as i32) << (c_int::BITS - 1);
-                    let q = (ql as i32) & clear | sign;
-
-                    (prep_retval::<Self::FTy>(&mut this.2, ord), q)
+                    let (ord, q) = this.0.remainder_quo31_round(&this.1, Nearest);
+                    (prep_retval::<Self::FTy>(&mut this.0, ord), q)
                 }
             }
 
@@ -544,25 +528,4 @@ impl MpOp for crate::op::nextafterf::Routine {
     fn run(_this: &mut Self::MpTy, _input: Self::RustArgs) -> Self::RustRet {
         unimplemented!("nextafter does not yet have a MPFR operation");
     }
-}
-
-/// `rug` does not provide `remquo` so this exposes `mpfr_remquo`. See rug#76.
-fn mpfr_remquo(r: &mut MpFloat, x: &MpFloat, y: &MpFloat, round: Round) -> (Ordering, c_long) {
-    let r = r.as_raw_mut();
-    let x = x.as_raw();
-    let y = y.as_raw();
-    let mut q: c_long = 0;
-
-    let round = match round {
-        Round::Nearest => rnd_t::RNDN,
-        Round::Zero => rnd_t::RNDZ,
-        Round::Up => rnd_t::RNDU,
-        Round::Down => rnd_t::RNDD,
-        Round::AwayZero => rnd_t::RNDA,
-        _ => unreachable!(),
-    };
-
-    // SAFETY: mutable and const pointers are valid and do not alias, by Rust's rules.
-    let ord = unsafe { gmp_mpfr_sys::mpfr::remquo(r, &mut q, x, y, round) };
-    (ord.cmp(&0), q)
 }

--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -408,15 +408,6 @@ impl MaybeOverride<(f32, f32)> for SpecialCase {
     ) -> CheckAction {
         binop_common(input, actual, expected, ctx)
     }
-
-    fn check_int<I: Int>(
-        _input: (f32, f32),
-        actual: I,
-        expected: I,
-        ctx: &CheckCtx,
-    ) -> CheckAction {
-        remquo_common(actual, expected, ctx)
-    }
 }
 
 impl MaybeOverride<(f64, f64)> for SpecialCase {
@@ -427,15 +418,6 @@ impl MaybeOverride<(f64, f64)> for SpecialCase {
         ctx: &CheckCtx,
     ) -> CheckAction {
         binop_common(input, actual, expected, ctx)
-    }
-
-    fn check_int<I: Int>(
-        _input: (f64, f64),
-        actual: I,
-        expected: I,
-        ctx: &CheckCtx,
-    ) -> CheckAction {
-        remquo_common(actual, expected, ctx)
     }
 }
 
@@ -494,19 +476,6 @@ fn binop_common<F1: Float, F2: Float>(
         && expected.is_nan()
     {
         return XFAIL("fmax/fmin musl NaN");
-    }
-
-    DEFAULT
-}
-
-fn remquo_common<I: Int>(actual: I, expected: I, ctx: &CheckCtx) -> CheckAction {
-    // FIXME: Our MPFR implementation disagrees with musl and may need to be updated.
-    if ctx.basis == CheckBasis::Mpfr
-        && ctx.base_name == BaseName::Remquo
-        && expected == I::MIN
-        && actual == I::ZERO
-    {
-        return XFAIL("remquo integer mismatch");
     }
 
     DEFAULT

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -16,4 +16,4 @@ libm = { path = "../..", default-features = false }
 libm-macros = { path = "../libm-macros" }
 libm-test = { path = "../libm-test", default-features = false }
 musl-math-sys = { path = "../musl-math-sys", optional = true }
-rug = { version = "1.26.1", optional = true, default-features = false, features = ["float", "std"] }
+rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "3d44b8d87d38c4a138fc74653a44ca9c518caac4", optional = true, default-features = false, features = ["float", "integer", "std"] }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -16,4 +16,4 @@ libm = { path = "../..", default-features = false }
 libm-macros = { path = "../libm-macros" }
 libm-test = { path = "../libm-test", default-features = false }
 musl-math-sys = { path = "../musl-math-sys", optional = true }
-rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "3d44b8d87d38c4a138fc74653a44ca9c518caac4", optional = true, default-features = false, features = ["float", "integer", "std"] }
+rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "2d96613fc1d84882b8651e86232fbb54ebe7c4c3", optional = true, default-features = false, features = ["float", "integer", "std"] }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -16,4 +16,4 @@ libm = { path = "../..", default-features = false }
 libm-macros = { path = "../libm-macros" }
 libm-test = { path = "../libm-test", default-features = false }
 musl-math-sys = { path = "../musl-math-sys", optional = true }
-rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "2d96613fc1d84882b8651e86232fbb54ebe7c4c3", optional = true, default-features = false, features = ["float", "integer", "std"] }
+rug = { git = "https://gitlab.com/tspiteri/rug.git", rev = "96d26fff459cc6be3f6c505a5bc55d14b9ac0222", optional = true, default-features = false, features = ["float", "integer", "std"] }

--- a/src/math/frexp.rs
+++ b/src/math/frexp.rs
@@ -1,3 +1,5 @@
+// poke ci
+
 pub fn frexp(x: f64) -> (f64, i32) {
     let mut y = x.to_bits();
     let ee = ((y >> 52) & 0x7ff) as i32;

--- a/src/math/frexpf.rs
+++ b/src/math/frexpf.rs
@@ -1,3 +1,5 @@
+// poke ci
+
 pub fn frexpf(x: f32) -> (f32, i32) {
     let mut y = x.to_bits();
     let ee: i32 = ((y >> 23) & 0xff) as i32;

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -1,3 +1,5 @@
+// poke ci
+
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
     let ux: u64 = x.to_bits();

--- a/src/math/remquof.rs
+++ b/src/math/remquof.rs
@@ -1,3 +1,5 @@
+// poke ci
+
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn remquof(mut x: f32, mut y: f32) -> (f32, i32) {
     let ux: u32 = x.to_bits();


### PR DESCRIPTION
Adds `frexp` and `remquo` that we can use directly.