### PR TITLE
Split a redundant condition in `fmod`

### DIFF
--- a/src/math/generic/fmod.rs
+++ b/src/math/generic/fmod.rs
@@ -46,10 +46,12 @@ pub fn fmod<F: Float>(x: F, y: F) -> F {
     /* x mod y */
     while ex > ey {
         let i = ix.wrapping_sub(iy);
-        if i >> (F::BITS - 1) == zero {
-            if i == zero {
-                return F::ZERO * x;
-            }
+
+        if i == zero {
+            return F::ZERO * x;
+        }
+
+        if i & F::SIGN_MASK == zero {
             ix = i;
         }
 


### PR DESCRIPTION
`i >> n == 0` implies `i == 0` so we don't need to check both. Breaking this out eliminates two labels and removes a few instructions in `fmod` on my machine.