### PR TITLE
Add support for printing hex float syntax

### DIFF
--- a/crates/libm-test/src/f8_impl.rs
+++ b/crates/libm-test/src/f8_impl.rs
@@ -3,6 +3,8 @@
 use std::cmp::{self, Ordering};
 use std::{fmt, ops};
 
+use libm::support::hex_float::parse_any;
+
 use crate::Float;
 
 /// Sometimes verifying float logic is easiest when all values can quickly be checked exhaustively
@@ -489,4 +491,8 @@ impl fmt::LowerHex for f8 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+pub const fn hf8(s: &str) -> f8 {
+    f8(parse_any(s, 8, 3) as u8)
 }

--- a/crates/libm-test/src/lib.rs
+++ b/crates/libm-test/src/lib.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::time::SystemTime;
 
-pub use f8_impl::f8;
+pub use f8_impl::{f8, hf8};
 pub use libm::support::{Float, Int, IntTy, MinInt};
 pub use num::{FloatExt, linear_ints, logspace};
 pub use op::{

--- a/crates/util/src/main.rs
+++ b/crates/util/src/main.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::num::ParseIntError;
 use std::str::FromStr;
 
-use libm::support::{hf32, hf64};
+use libm::support::{Hexf, hf32, hf64};
 #[cfg(feature = "build-mpfr")]
 use libm_test::mpfloat::MpOp;
 use libm_test::{MathOp, TupleCall};
@@ -73,7 +73,7 @@ macro_rules! handle_call {
                 }
                 _ => panic!("unrecognized or disabled basis '{}'", $basis),
             };
-            println!("{output:?}");
+            println!("{output:?} {:x}", Hexf(output));
             return;
         }
     };
@@ -303,6 +303,10 @@ impl FromStrRadix for i32 {
 #[cfg(f16_enabled)]
 impl FromStrRadix for f16 {
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError> {
+        if radix == 16 && s.contains("p") {
+            return Ok(libm::support::hf16(s));
+        }
+
         let s = strip_radix_prefix(s, radix);
         u16::from_str_radix(s, radix).map(Self::from_bits)
     }
@@ -334,6 +338,9 @@ impl FromStrRadix for f64 {
 #[cfg(f128_enabled)]
 impl FromStrRadix for f128 {
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, ParseIntError> {
+        if radix == 16 && s.contains("p") {
+            return Ok(libm::support::hf128(s));
+        }
         let s = strip_radix_prefix(s, radix);
         u128::from_str_radix(s, radix).map(Self::from_bits)
     }

--- a/src/math/support/mod.rs
+++ b/src/math/support/mod.rs
@@ -13,7 +13,7 @@ pub use hex_float::hf16;
 #[cfg(f128_enabled)]
 pub use hex_float::hf128;
 #[allow(unused_imports)]
-pub use hex_float::{hf32, hf64};
+pub use hex_float::{Hexf, hf32, hf64};
 pub use int_traits::{CastFrom, CastInto, DInt, HInt, Int, MinInt};
 
 /// Hint to the compiler that the current path is cold.

--- a/src/math/support/mod.rs
+++ b/src/math/support/mod.rs
@@ -2,7 +2,7 @@
 pub mod macros;
 mod big;
 mod float_traits;
-mod hex_float;
+pub mod hex_float;
 mod int_traits;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
Update the `hf*` functions to be able to parse infinities and NANs, then add a wrapper type that formats with the hex float syntax.

For now this is only being used in `util`, but in a followup I will somehow merge this into the existing `Hex` trait so this is displayed from test output.