### PR TITLE
Temporarily pin `indicatif` to 0.17.9

### DIFF
--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -31,7 +31,8 @@ anyhow = "1.0.95"
 # This is not directly used but is required so we can enable `gmp-mpfr-sys/force-cross`.
 gmp-mpfr-sys = { version = "1.6.4", optional = true, default-features = false }
 iai-callgrind = { version = "0.14.0", optional = true }
-indicatif = { version = "0.17.9", default-features = false }
+# 0.17.10 made `ProgressStyle` non-`Sync`
+indicatif = { version = "=0.17.9", default-features = false }
 libm = { path = "../..", features = ["unstable-public-internals"] }
 libm-macros = { path = "../libm-macros" }
 musl-math-sys = { path = "../musl-math-sys", optional = true }


### PR DESCRIPTION
0.17.10 introduced a change that removes `Sync` from `ProgressStyle`, which makes it more difficult to share in a callback. Pin the dependency for now until we see if `indicatif` will change this back or if we need to find a workaround.