### PR TITLE
Revert "Temporarily pin `indicatif` to 0.17.9"

### DIFF
--- a/crates/libm-test/Cargo.toml
+++ b/crates/libm-test/Cargo.toml
@@ -31,8 +31,7 @@ anyhow = "1.0.95"
 # This is not directly used but is required so we can enable `gmp-mpfr-sys/force-cross`.
 gmp-mpfr-sys = { version = "1.6.4", optional = true, default-features = false }
 iai-callgrind = { version = "0.14.0", optional = true }
-# 0.17.10 made `ProgressStyle` non-`Sync`
-indicatif = { version = "=0.17.9", default-features = false }
+indicatif = { version = "0.17.9", default-features = false }
 libm = { path = "../..", features = ["unstable-public-internals"] }
 libm-macros = { path = "../libm-macros" }
 musl-math-sys = { path = "../musl-math-sys", optional = true }


### PR DESCRIPTION
Reverts rust-lang/libm#484

The latest `indicatif` release 0.17.11 resolves the `Sync` issue, so we no longer need to keep it pinned.