### PR TITLE
Rename `EXP_MAX` to `EXP_SAT`

### DIFF
--- a/src/math/generic/fmod.rs
+++ b/src/math/generic/fmod.rs
@@ -13,7 +13,7 @@ pub fn fmod<F: Float>(x: F, y: F) -> F {
     let mut ey = y.exp().signed();
     let sx = ix & F::SIGN_MASK;
 
-    if iy << 1 == zero || y.is_nan() || ex == F::EXP_MAX as i32 {
+    if iy << 1 == zero || y.is_nan() || ex == F::EXP_SAT as i32 {
         return (x * y) / (x * y);
     }
 

--- a/src/math/generic/sqrt.rs
+++ b/src/math/generic/sqrt.rs
@@ -68,7 +68,7 @@ where
         (Exp::NoShift(()), special_case)
     } else {
         let top = u32::cast_from(ix >> F::SIG_BITS);
-        let special_case = top.wrapping_sub(1) >= F::EXP_MAX - 1;
+        let special_case = top.wrapping_sub(1) >= F::EXP_SAT - 1;
         (Exp::Shifted(top), special_case)
     };
 
@@ -119,7 +119,7 @@ where
             if even {
                 m_u2 >>= 1;
             }
-            e = (e.wrapping_add(F::EXP_MAX >> 1)) >> 1;
+            e = (e.wrapping_add(F::EXP_SAT >> 1)) >> 1;
             (m_u2, Exp::Shifted(e))
         }
         Exp::NoShift(()) => {


### PR DESCRIPTION
`EXP_MAX` sounds like it would be the maximum value representable by that float type's exponent, rather than the maximum unsigned value of its bits. Clarify this by renaming to `EXP_SAT`, the "saturated" exponent representation.