### PR TITLE
Commonize the signature for all instances of `get_test_cases`

### DIFF
--- a/crates/libm-test/benches/random.rs
+++ b/crates/libm-test/benches/random.rs
@@ -54,7 +54,7 @@ where
 
     let ctx = CheckCtx::new(Op::IDENTIFIER, CheckBasis::Musl, GeneratorKind::Random);
     let benchvec: Vec<_> =
-        random::get_test_cases::<Op::RustArgs>(&ctx).take(BENCH_ITER_ITEMS).collect();
+        random::get_test_cases::<Op::RustArgs>(&ctx).0.take(BENCH_ITER_ITEMS).collect();
 
     // Perform a sanity check that we are benchmarking the same thing
     // Don't test against musl if it is not available

--- a/crates/libm-test/examples/plot_domains.rs
+++ b/crates/libm-test/examples/plot_domains.rs
@@ -58,7 +58,13 @@ where
     let mut ctx = CheckCtx::new(Op::IDENTIFIER, CheckBasis::Mpfr, GeneratorKind::QuickSpaced);
     plot_one_generator(out_dir, &ctx, "logspace", config, spaced::get_test_cases::<Op>(&ctx).0);
     ctx.gen_kind = GeneratorKind::EdgeCases;
-    plot_one_generator(out_dir, &ctx, "edge_cases", config, edge_cases::get_test_cases::<Op>(&ctx));
+    plot_one_generator(
+        out_dir,
+        &ctx,
+        "edge_cases",
+        config,
+        edge_cases::get_test_cases::<Op>(&ctx).0,
+    );
 }
 
 /// Plot the output of a single generator.

--- a/crates/libm-test/tests/compare_built_musl.rs
+++ b/crates/libm-test/tests/compare_built_musl.rs
@@ -39,7 +39,7 @@ macro_rules! musl_tests {
             fn [< musl_random_ $fn_name >]() {
                 type Op = libm_test::op::$fn_name::Routine;
                 let ctx = CheckCtx::new(Op::IDENTIFIER, BASIS, GeneratorKind::Random);
-                let cases = random::get_test_cases::<<Op as MathOp>::RustArgs>(&ctx);
+                let cases = random::get_test_cases::<<Op as MathOp>::RustArgs>(&ctx).0;
                 musl_runner::<Op>(&ctx, cases, musl_math_sys::$fn_name);
             }
 
@@ -48,7 +48,7 @@ macro_rules! musl_tests {
             fn [< musl_edge_case_ $fn_name >]() {
                 type Op = libm_test::op::$fn_name::Routine;
                 let ctx = CheckCtx::new(Op::IDENTIFIER, BASIS, GeneratorKind::EdgeCases);
-                let cases = edge_cases::get_test_cases::<Op>(&ctx);
+                let cases = edge_cases::get_test_cases::<Op>(&ctx).0;
                 musl_runner::<Op>(&ctx, cases, musl_math_sys::$fn_name);
             }
 

--- a/crates/libm-test/tests/multiprecision.rs
+++ b/crates/libm-test/tests/multiprecision.rs
@@ -29,7 +29,7 @@ macro_rules! mp_tests {
             fn [< mp_random_ $fn_name >]() {
                 type Op = libm_test::op::$fn_name::Routine;
                 let ctx = CheckCtx::new(Op::IDENTIFIER, BASIS, GeneratorKind::Random);
-                let cases = random::get_test_cases::<<Op as MathOp>::RustArgs>(&ctx);
+                let cases = random::get_test_cases::<<Op as MathOp>::RustArgs>(&ctx).0;
                 mp_runner::<Op>(&ctx, cases);
             }
 
@@ -38,7 +38,7 @@ macro_rules! mp_tests {
             fn [< mp_edge_case_ $fn_name >]() {
                 type Op = libm_test::op::$fn_name::Routine;
                 let ctx = CheckCtx::new(Op::IDENTIFIER, BASIS, GeneratorKind::EdgeCases);
-                let cases = edge_cases::get_test_cases::<Op>(&ctx);
+                let cases = edge_cases::get_test_cases::<Op>(&ctx).0;
                 mp_runner::<Op>(&ctx, cases);
             }
 


### PR DESCRIPTION
In order to make these more interchangeable in more places, always return `(impl Iterator, u64)`. This will facilitate using other generators for extensive tests.