### PR TITLE
Remove or reduce the scope of `allow(unused)` where possible

### DIFF
--- a/crates/libm-macros/tests/basic.rs
+++ b/crates/libm-macros/tests/basic.rs
@@ -18,20 +18,14 @@ macro_rules! basic {
         fn_extra: $fn_extra:expr,
     ) => {
         $(#[$attr])*
-        mod $fn_name {
-            #[allow(unused)]
+        #[allow(dead_code)]
+        pub mod $fn_name {
             type FTy= $FTy;
-            #[allow(unused)]
             type CFnTy<'a> = $CFn;
-            #[allow(unused)]
             type RustFnTy = $RustFn;
-            #[allow(unused)]
             type RustArgsTy = $RustArgs;
-            #[allow(unused)]
             type RustRetTy = $RustRet;
-            #[allow(unused)]
             const A: &[&str] = &[$($extra_tt)*];
-            #[allow(unused)]
             fn foo(a: f32) -> f32 {
                 $fn_extra(a)
             }
@@ -92,10 +86,9 @@ macro_rules! specified_types {
         attrs: [$($attr:meta),*],
     ) => {
         $(#[$attr])*
+        #[allow(dead_code)]
         mod $fn_name {
-            #[allow(unused)]
             type RustFnTy = $RustFn;
-            #[allow(unused)]
             type RustArgsTy = $RustArgs;
         }
     };

--- a/src/math/support/big.rs
+++ b/src/math/support/big.rs
@@ -1,11 +1,9 @@
 //! Integers used for wide operations, larger than `u128`.
 
-#![allow(unused)]
-
 #[cfg(test)]
 mod tests;
 
-use core::{fmt, ops};
+use core::ops;
 
 use super::{DInt, HInt, Int, MinInt};
 
@@ -13,7 +11,6 @@ const WORD_LO_MASK: u64 = 0x00000000ffffffff;
 const WORD_HI_MASK: u64 = 0xffffffff00000000;
 const WORD_FULL_MASK: u64 = 0xffffffffffffffff;
 const U128_LO_MASK: u128 = u64::MAX as u128;
-const U128_HI_MASK: u128 = (u64::MAX as u128) << 64;
 
 /// A 256-bit unsigned integer represented as 4 64-bit limbs.
 ///
@@ -23,6 +20,7 @@ const U128_HI_MASK: u128 = (u64::MAX as u128) << 64;
 pub struct u256(pub [u64; 4]);
 
 impl u256 {
+    #[cfg(test)]
     pub const MAX: Self = Self([u64::MAX, u64::MAX, u64::MAX, u64::MAX]);
 
     /// Reinterpret as a signed integer
@@ -40,6 +38,7 @@ pub struct i256(pub [u64; 4]);
 
 impl i256 {
     /// Reinterpret as an unsigned integer
+    #[cfg(test)]
     pub fn unsigned(self) -> u256 {
         u256(self.0)
     }
@@ -96,7 +95,7 @@ macro_rules! impl_common {
         impl ops::Shl<u32> for $ty {
             type Output = Self;
 
-            fn shl(self, rhs: u32) -> Self::Output {
+            fn shl(self, _rhs: u32) -> Self::Output {
                 unimplemented!("only used to meet trait bounds")
             }
         }
@@ -256,7 +255,7 @@ impl HInt for i128 {
         self.unsigned().zero_widen_mul(rhs.unsigned()).signed()
     }
 
-    fn widen_mul(self, rhs: Self) -> Self::D {
+    fn widen_mul(self, _rhs: Self) -> Self::D {
         unimplemented!("signed i128 widening multiply is not used")
     }
 

--- a/src/math/support/float_traits.rs
+++ b/src/math/support/float_traits.rs
@@ -3,7 +3,7 @@ use core::{fmt, mem, ops};
 use super::int_traits::{CastFrom, Int, MinInt};
 
 /// Trait for some basic operations on floats
-#[allow(dead_code)]
+// #[allow(dead_code)]
 pub trait Float:
     Copy
     + fmt::Debug
@@ -84,11 +84,13 @@ pub trait Float:
     fn to_bits(self) -> Self::Int;
 
     /// Returns `self` transmuted to `Self::SignedInt`
+    #[allow(dead_code)]
     fn to_bits_signed(self) -> Self::SignedInt {
         self.to_bits().signed()
     }
 
     /// Check bitwise equality.
+    #[allow(dead_code)]
     fn biteq(self, rhs: Self) -> bool {
         self.to_bits() == rhs.to_bits()
     }
@@ -98,6 +100,7 @@ pub trait Float:
     ///
     /// This method returns `true` if two NaNs are compared. Use [`biteq`](Self::biteq) instead
     /// if `NaN` should not be treated separately.
+    #[allow(dead_code)]
     fn eq_repr(self, rhs: Self) -> bool {
         if self.is_nan() && rhs.is_nan() { true } else { self.biteq(rhs) }
     }
@@ -117,6 +120,7 @@ pub trait Float:
     }
 
     /// Returns if `self` is subnormal.
+    #[allow(dead_code)]
     fn is_subnormal(self) -> bool {
         (self.to_bits() & Self::EXP_MASK) == Self::Int::ZERO
     }
@@ -132,13 +136,9 @@ pub trait Float:
     }
 
     /// Returns the significand with no implicit bit (or the "fractional" part)
+    #[allow(dead_code)]
     fn frac(self) -> Self::Int {
         self.to_bits() & Self::SIG_MASK
-    }
-
-    /// Returns the significand with implicit bit.
-    fn imp_frac(self) -> Self::Int {
-        self.frac() | Self::IMPLICIT_BIT
     }
 
     /// Returns a `Self::Int` transmuted back to `Self`
@@ -154,22 +154,25 @@ pub trait Float:
         )
     }
 
+    #[allow(dead_code)]
     fn abs(self) -> Self;
 
     /// Returns a number composed of the magnitude of self and the sign of sign.
+    #[allow(dead_code)]
     fn copysign(self, other: Self) -> Self;
 
     /// Returns (normalized exponent, normalized significand)
+    #[allow(dead_code)]
     fn normalize(significand: Self::Int) -> (i32, Self::Int);
 
     /// Returns a number that represents the sign of self.
+    #[allow(dead_code)]
     fn signum(self) -> Self {
         if self.is_nan() { self } else { Self::ONE.copysign(self) }
     }
 }
 
 /// Access the associated `Int` type from a float (helper to avoid ambiguous associated types).
-#[allow(dead_code)]
 pub type IntTy<F> = <F as Float>::Int;
 
 macro_rules! float_impl {

--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -1,7 +1,6 @@
 use core::{cmp, fmt, ops};
 
 /// Minimal integer implementations needed on all integer types, including wide integers.
-#[allow(dead_code)]
 pub trait MinInt:
     Copy
     + fmt::Debug
@@ -261,7 +260,6 @@ int_impl!(i128, u128);
 
 /// Trait for integers twice the bit width of another integer. This is implemented for all
 /// primitives except for `u8`, because there is not a smaller primitive.
-#[allow(unused)]
 pub trait DInt: MinInt {
     /// Integer that is half the bit width of the integer this trait is implemented for
     type H: HInt<D = Self>;
@@ -275,6 +273,7 @@ pub trait DInt: MinInt {
         (self.lo(), self.hi())
     }
     /// Constructs an integer using lower and higher half parts
+    #[allow(unused)]
     fn from_lo_hi(lo: Self::H, hi: Self::H) -> Self {
         lo.zero_widen() | hi.widen_hi()
     }
@@ -282,7 +281,6 @@ pub trait DInt: MinInt {
 
 /// Trait for integers half the bit width of another integer. This is implemented for all
 /// primitives except for `u128`, because it there is not a larger primitive.
-#[allow(unused)]
 pub trait HInt: Int {
     /// Integer that is double the bit width of the integer this trait is implemented for
     type D: DInt<H = Self> + MinInt;
@@ -297,6 +295,7 @@ pub trait HInt: Int {
     /// around problems with associated type bounds (such as `Int<Othersign: DInt>`) being unstable
     fn zero_widen(self) -> Self::D;
     /// Widens the integer to have double bit width and shifts the integer into the higher bits
+    #[allow(unused)]
     fn widen_hi(self) -> Self::D;
     /// Widening multiplication with zero widening. This cannot overflow.
     fn zero_widen_mul(self, rhs: Self) -> Self::D;
@@ -360,7 +359,6 @@ impl_h_int!(
 );
 
 /// Trait to express (possibly lossy) casting of integers
-#[allow(unused)]
 pub trait CastInto<T: Copy>: Copy {
     /// By default, casts should be exact.
     fn cast(self) -> T;
@@ -369,7 +367,6 @@ pub trait CastInto<T: Copy>: Copy {
     fn cast_lossy(self) -> T;
 }
 
-#[allow(unused)]
 pub trait CastFrom<T: Copy>: Copy {
     /// By default, casts should be exact.
     fn cast_from(value: T) -> Self;

--- a/src/math/support/mod.rs
+++ b/src/math/support/mod.rs
@@ -5,7 +5,6 @@ mod float_traits;
 pub mod hex_float;
 mod int_traits;
 
-#[allow(unused_imports)]
 pub use float_traits::{Float, IntTy};
 pub(crate) use float_traits::{f32_from_bits, f64_from_bits};
 #[cfg(f16_enabled)]


### PR DESCRIPTION
Now that we have more in this crate making use of traits, try to be more specific about what is actually unused.