### PR TITLE
Rename `Float::exp` to `Float::ex`

### DIFF
--- a/etc/function-definitions.json
+++ b/etc/function-definitions.json
@@ -206,8 +206,7 @@
     },
     "exp": {
         "sources": [
-            "src/math/exp.rs",
-            "src/math/support/float_traits.rs"
+            "src/math/exp.rs"
         ],
         "type": "f64"
     },

--- a/src/math/generic/fma.rs
+++ b/src/math/generic/fma.rs
@@ -249,7 +249,7 @@ where
     let xy: B = x.widen() * y.widen();
     let mut result: B = xy + z.widen();
     let mut ui: B::Int = result.to_bits();
-    let re = result.exp();
+    let re = result.ex();
     let zb: B = z.widen();
 
     let prec_diff = B::SIG_BITS - F::SIG_BITS;
@@ -318,7 +318,7 @@ impl<F: Float> Norm<F> {
 
     fn from_float(x: F) -> Self {
         let mut ix = x.to_bits();
-        let mut e = x.exp() as i32;
+        let mut e = x.ex() as i32;
         let neg = x.is_sign_negative();
         if e == 0 {
             // Normalize subnormals by multiplication
@@ -326,7 +326,7 @@ impl<F: Float> Norm<F> {
             let scale_f = F::from_parts(false, scale_i + F::EXP_BIAS, F::Int::ZERO);
             let scaled = x * scale_f;
             ix = scaled.to_bits();
-            e = scaled.exp() as i32;
+            e = scaled.ex() as i32;
             e = if e == 0 {
                 // If the exponent is still zero, the input was zero. Artifically set this value
                 // such that the final `e` will exceed `ZERO_INF_NAN`.

--- a/src/math/generic/fmod.rs
+++ b/src/math/generic/fmod.rs
@@ -9,8 +9,8 @@ pub fn fmod<F: Float>(x: F, y: F) -> F {
     let one = F::Int::ONE;
     let mut ix = x.to_bits();
     let mut iy = y.to_bits();
-    let mut ex = x.exp().signed();
-    let mut ey = y.exp().signed();
+    let mut ex = x.ex().signed();
+    let mut ey = y.ex().signed();
     let sx = ix & F::SIGN_MASK;
 
     if iy << 1 == zero || y.is_nan() || ex == F::EXP_SAT as i32 {

--- a/src/math/generic/rint.rs
+++ b/src/math/generic/rint.rs
@@ -8,7 +8,7 @@ use super::super::support::{FpResult, Round};
 /// applicable.
 pub fn rint_round<F: Float>(x: F, _round: Round) -> FpResult<F> {
     let toint = F::ONE / F::EPSILON;
-    let e = x.exp();
+    let e = x.ex();
     let positive = x.is_sign_positive();
 
     // On i386 `force_eval!` must be used to force rounding via storage to memory. Otherwise,

--- a/src/math/generic/sqrt.rs
+++ b/src/math/generic/sqrt.rs
@@ -109,7 +109,7 @@ where
         ix = scaled.to_bits();
         match top {
             Exp::Shifted(ref mut v) => {
-                *v = scaled.exp();
+                *v = scaled.ex();
                 *v = (*v).wrapping_sub(F::SIG_BITS);
             }
             Exp::NoShift(()) => {

--- a/src/math/support/float_traits.rs
+++ b/src/math/support/float_traits.rs
@@ -128,13 +128,13 @@ pub trait Float:
     }
 
     /// Returns the exponent, not adjusting for bias, not accounting for subnormals or zero.
-    fn exp(self) -> u32 {
+    fn ex(self) -> u32 {
         u32::cast_from(self.to_bits() >> Self::SIG_BITS) & Self::EXP_SAT
     }
 
     /// Extract the exponent and adjust it for bias, not accounting for subnormals or zero.
     fn exp_unbiased(self) -> i32 {
-        self.exp().signed() - (Self::EXP_BIAS as i32)
+        self.ex().signed() - (Self::EXP_BIAS as i32)
     }
 
     /// Returns the significand with no implicit bit (or the "fractional" part)


### PR DESCRIPTION
Our function to get the exponent conflicts with the inherent `exp` function for `e^x`. Rename `exp` to `ex` to avoid confusion and usage problems.