### PR TITLE
Resolve monomorphization errors in `compiler-builtins`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,13 @@ exclude = [
 [dev-dependencies]
 no-panic = "0.1.33"
 
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  # compiler-builtins sets this feature, but we use it in `libm`
+  'cfg(feature, values("compiler-builtins"))',
+] }
+
 # The default release profile is unchanged.
 
 # Release mode with debug assertions

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -22,6 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   "cfg(arch_enabled)",
   "cfg(assert_no_panic)",
   "cfg(intrinsics_enabled)",
+  'cfg(feature, values("compiler-builtins"))',
   'cfg(feature, values("force-soft-floats"))',
   'cfg(feature, values("unstable"))',
   'cfg(feature, values("unstable-intrinsics"))',

--- a/crates/compiler-builtins-smoke-test/src/lib.rs
+++ b/crates/compiler-builtins-smoke-test/src/lib.rs
@@ -4,7 +4,9 @@
 //! Additionally, it provides a `#[no_mangle]` C API that can be easier to inspect than the
 //! default `.rlib`.
 
+#![compiler_builtins]
 #![feature(core_intrinsics)]
+#![feature(compiler_builtins)]
 #![feature(f16)]
 #![feature(f128)]
 #![allow(internal_features)]

--- a/src/math/support/hex_float.rs
+++ b/src/math/support/hex_float.rs
@@ -246,7 +246,13 @@ fn fmt_any_hex<F: Float>(x: &F, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 
 impl<F: Float> fmt::LowerHex for Hexf<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_any_hex(&self.0, f)
+        cfg_if! {
+            if #[cfg(feature = "compiler-builtins")] {
+                unreachable!()
+            } else {
+                fmt_any_hex(&self.0, f)
+            }
+        }
     }
 }
 
@@ -264,7 +270,13 @@ impl<F: Float> fmt::LowerHex for Hexf<(F, i32)> {
 
 impl fmt::LowerHex for Hexf<i32> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.0, f)
+        cfg_if! {
+            if #[cfg(feature = "compiler-builtins")] {
+                unreachable!()
+            } else {
+                fmt::LowerHex::fmt(&self.0, f)
+            }
+        }
     }
 }
 

--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -418,6 +418,7 @@ macro_rules! cast_into_float {
     ($ty:ty; $($into:ty),*) => {$(
         impl CastInto<$into> for $ty {
             fn cast(self) -> $into {
+                #[cfg(not(feature = "compiler-builtins"))]
                 debug_assert_eq!(self as $into as $ty, self, "inexact float cast");
                 self as $into
             }


### PR DESCRIPTION
`compiler-builtins` is not allowed to call anything from `core`; however, there are a couple of cases where we do so in `libm` for debug output. Gate relevant locations behind the `compiler-builtins` Cargo feature.