### PR TITLE
Gate another assertion behind `compiler-builtins`

### DIFF
--- a/src/math/support/int_traits.rs
+++ b/src/math/support/int_traits.rs
@@ -394,6 +394,7 @@ macro_rules! cast_into {
             fn cast(self) -> $into {
                 // All we can really do to enforce casting rules is check the rules when in
                 // debug mode.
+                #[cfg(not(feature = "compiler-builtins"))]
                 debug_assert!(<$into>::try_from(self).is_ok(), "failed cast from {self}");
                 self as $into
             }


### PR DESCRIPTION
This is causing link errors on Windows and some other platforms, https://github.com/rust-lang/compiler-builtins/actions/runs/13492055192/job/37691796047?pr=765.