### PR TITLE
Reenable the use of the force-soft-floats feature

### DIFF
--- a/crates/libm-test/src/precision.rs
+++ b/crates/libm-test/src/precision.rs
@@ -106,11 +106,10 @@ pub fn default_ulp(ctx: &CheckCtx) -> u32 {
     }
 
     if cfg!(target_arch = "x86") {
-        match ctx.fn_ident {
-            // Input `fma(0.999999999999999, 1.0000000000000013, 0.0) = 1.0000000000000002` is
-            // incorrect on i586 and i686.
-            Id::Fma => ulp = 1,
-            _ => (),
+        // Input `fma(0.999999999999999, 1.0000000000000013, 0.0) = 1.0000000000000002` is
+        // incorrect on i586 and i686.
+        if ctx.fn_ident == Id::Fma {
+            ulp = 1
         }
     }
 

--- a/src/math/arch/i686.rs
+++ b/src/math/arch/i686.rs
@@ -1,5 +1,7 @@
 //! Architecture-specific support for x86-32 and x86-64 with SSE2
 
+#![cfg(not(feature = "force-soft-floats"))]
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -5,7 +5,11 @@ pub fn sqrt(x: f64) -> f64 {
         name: sqrt,
         use_arch: any(
             all(target_arch = "wasm32", intrinsics_enabled),
-            target_feature = "sse2"
+            // Codegen backends (e.g. rustc_codegen_gcc) that implement intrinsics like simd_fsqrt
+            // by calling sqrt on every element of the vector ends up with an infinite recursion
+            // without the force-soft-floats feature because sqrt would call simd_fsqrt, which in
+            // turn calls sqrt on those codegen backends.
+            all(target_feature = "sse2", not(feature = "force-soft-floats"))
         ),
         args: x,
     }

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -5,7 +5,11 @@ pub fn sqrtf(x: f32) -> f32 {
         name: sqrtf,
         use_arch: any(
             all(target_arch = "wasm32", intrinsics_enabled),
-            target_feature = "sse2"
+            // Codegen backends (e.g. rustc_codegen_gcc) that implement intrinsics like simd_fsqrt
+            // by calling sqrt on every element of the vector ends up with an infinite recursion
+            // without the force-soft-floats feature because sqrt would call simd_fsqrt, which in
+            // turn calls sqrt on those codegen backends.
+            all(target_feature = "sse2", not(feature = "force-soft-floats"))
         ),
         args: x,
     }

--- a/src/math/support/env.rs
+++ b/src/math/support/env.rs
@@ -70,7 +70,6 @@ impl Status {
     /// The default result for division is +/-inf based on operand sign. For `logB`, the default
     /// result is -inf.
     /// `x / y` when `x != 0.0` and `y == 0.0`,
-
     #[cfg_attr(not(feature = "unstable-public-internals"), allow(dead_code))]
     pub const DIVIDE_BY_ZERO: Self = Self(1 << 2);
 


### PR DESCRIPTION
This fixes an infinite recursion in sqrt for codegen backends that implement intrinsics like simd_fsqrt by calling sqrt on every element of the vector.

This is going to be needed to fix https://github.com/rust-lang/compiler-builtins/issues/649.

I was able to test this locally by changing some other code (basically having an implementation of `_mm_sqrt_pd` that calls the local `sqrt` function on all elements of the vector).
Do you have any ideas for how to add a test for this? Perhaps by including this implementation of `_mm_sqrt_pd` behind a `#[cfg]`?