### PR TITLE
ci: Cancel jobs when a new push happens

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,11 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # Make sure that new pushes cancel running jobs
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: -Dwarnings


### PR DESCRIPTION
Jobs should just cancel automatically, it isn't ideal that extensive jobs can continue running for multiple hours after code has been updated. Use a solution from [1] to do this.

[1]: https://stackoverflow.com/a/72408109/5380651