### PR TITLE
Combine the source files for `fmod`

### DIFF
--- a/etc/function-definitions.json
+++ b/etc/function-definitions.json
@@ -537,21 +537,21 @@
     },
     "fmodf": {
         "sources": [
-            "src/math/fmodf.rs",
+            "src/math/fmod.rs",
             "src/math/generic/fmod.rs"
         ],
         "type": "f32"
     },
     "fmodf128": {
         "sources": [
-            "src/math/fmodf128.rs",
+            "src/math/fmod.rs",
             "src/math/generic/fmod.rs"
         ],
         "type": "f128"
     },
     "fmodf16": {
         "sources": [
-            "src/math/fmodf16.rs",
+            "src/math/fmod.rs",
             "src/math/generic/fmod.rs"
         ],
         "type": "f16"

--- a/src/math/fmod.rs
+++ b/src/math/fmod.rs
@@ -1,5 +1,25 @@
 /// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
+#[cfg(f16_enabled)]
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn fmodf16(x: f16, y: f16) -> f16 {
+    super::generic::fmod(x, y)
+}
+
+/// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn fmodf(x: f32, y: f32) -> f32 {
+    super::generic::fmod(x, y)
+}
+
+/// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmod(x: f64, y: f64) -> f64 {
+    super::generic::fmod(x, y)
+}
+
+/// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
+#[cfg(f128_enabled)]
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub fn fmodf128(x: f128, y: f128) -> f128 {
     super::generic::fmod(x, y)
 }

--- a/src/math/fmodf.rs
+++ b/src/math/fmodf.rs
@@ -1,5 +1,0 @@
-/// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
-#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmodf(x: f32, y: f32) -> f32 {
-    super::generic::fmod(x, y)
-}

--- a/src/math/fmodf128.rs
+++ b/src/math/fmodf128.rs
@@ -1,5 +1,0 @@
-/// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
-#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmodf128(x: f128, y: f128) -> f128 {
-    super::generic::fmod(x, y)
-}

--- a/src/math/fmodf16.rs
+++ b/src/math/fmodf16.rs
@@ -1,5 +1,0 @@
-/// Calculate the remainder of `x / y`, the precise result of `x - trunc(x / y) * y`.
-#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmodf16(x: f16, y: f16) -> f16 {
-    super::generic::fmod(x, y)
-}

--- a/src/math/frexp.rs
+++ b/src/math/frexp.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn frexp(x: f64) -> (f64, i32) {
     let mut y = x.to_bits();
     let ee = ((y >> 52) & 0x7ff) as i32;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -164,7 +164,6 @@ mod fmin_fmax;
 mod fminimum_fmaximum;
 mod fminimum_fmaximum_num;
 mod fmod;
-mod fmodf;
 mod frexp;
 mod frexpf;
 mod hypot;
@@ -260,8 +259,7 @@ pub use self::fma_wide::fmaf;
 pub use self::fmin_fmax::{fmax, fmaxf, fmin, fminf};
 pub use self::fminimum_fmaximum::{fmaximum, fmaximumf, fminimum, fminimumf};
 pub use self::fminimum_fmaximum_num::{fmaximum_num, fmaximum_numf, fminimum_num, fminimum_numf};
-pub use self::fmod::fmod;
-pub use self::fmodf::fmodf;
+pub use self::fmod::{fmod, fmodf};
 pub use self::frexp::frexp;
 pub use self::frexpf::frexpf;
 pub use self::hypot::hypot;
@@ -319,10 +317,6 @@ pub use self::trunc::{trunc, truncf};
 cfg_if! {
     if #[cfg(f16_enabled)] {
         // verify-sorted-start
-        mod fmodf16;
-        // verify-sorted-end
-
-        // verify-sorted-start
         pub use self::ceil::ceilf16;
         pub use self::copysign::copysignf16;
         pub use self::fabs::fabsf16;
@@ -331,7 +325,7 @@ cfg_if! {
         pub use self::fmin_fmax::{fmaxf16, fminf16};
         pub use self::fminimum_fmaximum::{fmaximumf16, fminimumf16};
         pub use self::fminimum_fmaximum_num::{fmaximum_numf16, fminimum_numf16};
-        pub use self::fmodf16::fmodf16;
+        pub use self::fmod::fmodf16;
         pub use self::ldexp::ldexpf16;
         pub use self::rint::rintf16;
         pub use self::round::roundf16;
@@ -349,10 +343,6 @@ cfg_if! {
 cfg_if! {
     if #[cfg(f128_enabled)] {
         // verify-sorted-start
-        mod fmodf128;
-        // verify-sorted-end
-
-        // verify-sorted-start
         pub use self::ceil::ceilf128;
         pub use self::copysign::copysignf128;
         pub use self::fabs::fabsf128;
@@ -362,7 +352,7 @@ cfg_if! {
         pub use self::fmin_fmax::{fmaxf128, fminf128};
         pub use self::fminimum_fmaximum::{fmaximumf128, fminimumf128};
         pub use self::fminimum_fmaximum_num::{fmaximum_numf128, fminimum_numf128};
-        pub use self::fmodf128::fmodf128;
+        pub use self::fmod::fmodf128;
         pub use self::ldexp::ldexpf128;
         pub use self::rint::rintf128;
         pub use self::round::roundf128;


### PR DESCRIPTION
Since `fmod` is generic, there isn't any need to have the small wrappers in separate files. Most operations was done in [1] but `fmod` was omitted until now.

[1]: https://github.com/rust-lang/libm/pull/537

ci: skip-extensive