### PR TITLE
Note that this crate has been moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A port of [MUSL]'s libm to Rust.
 
+> [!NOTE]  
+> The `libm` crate has been merged into the `compiler-builtins` repository. Future
+> development work will take place there: https://github.com/rust-lang/compiler-builtins.
+
 [MUSL]: https://musl.libc.org/
 
 ## Goals


### PR DESCRIPTION
Since [1], `libm` is now part of the `compiler-builtins` repositoy, so this repo will be archived. Update the README to reflect that.

[1]: https://github.com/rust-lang/compiler-builtins/pull/822